### PR TITLE
docs / add beta testing note for rpi via docker

### DIFF
--- a/content/installation/raspberry.mdx
+++ b/content/installation/raspberry.mdx
@@ -5,7 +5,9 @@ description: Raspberry installation Guide
 
 import { MultiCodeBlock } from "gatsby-theme-apollo-docs";
 
-## Install via Docker
+## Install via Docker (BETA)
+
+> **Note:** This installation method is currently under testing and awaiting feedback from users. Should you run into problems or have found a fix to solve errors along the way, feel free to reach out through our [Discord](http://discord.hummingbot.io/) support channel.
 
 You can install Hummingbot with **_either_** of the following options:
 


### PR DESCRIPTION
Added BETA tag to Raspberry Pi via Docker installation and note.

<img width="1129" alt="Screen Shot 2020-10-17 at 2 47 05 PM" src="https://user-images.githubusercontent.com/50150287/96330439-c237d380-1087-11eb-90e9-89ddbc385dc1.png">