### PR TITLE
doc/ fix hyperlinks across the docs

### DIFF
--- a/content/connectors/bamboo-relay.mdx
+++ b/content/connectors/bamboo-relay.mdx
@@ -10,8 +10,8 @@ description: About Bamboo Relay Connector
 
 Because Bamboo Relay is a decentralized exchange, you will need an independent cryptocurrency wallet and an ethereum node in order to use Hummingbot. See below for information on how to create these:
 
-* [Creating a crypto wallet](/advanced/wallet)
-* [Creating an ethereum node](/advanced/node)
+* [Creating a crypto wallet](/operation/adv-command-ref/#setup-ethereum-wallet)
+* [Creating an ethereum node](/operation/adv-command-ref/#setup-ethereum-nodes)
 
 ## Connector Operating Modes
 

--- a/content/connectors/binance.mdx
+++ b/content/connectors/binance.mdx
@@ -64,4 +64,4 @@ Users can override the default fees by editing [`conf_fee_overrides.yml`](/opera
 
 You can use an API key from a [Binance sub-account](https://medium.com/binanceexchange/binance-introduces-sub-account-support-d7bf2f95e28c) just like you do for a normal Binance account. Please ensure that you use the **sub-account API key** and not the master account API key.
 
-If you are participating in [Liquidity Mining](/liquidity-mining), please also use the **sub-account read-only API key** when you sign up.
+If you are participating in [Liquidity Mining](/intro/liquidity-mining), please also use the **sub-account read-only API key** when you sign up.

--- a/content/connectors/dolomite.mdx
+++ b/content/connectors/dolomite.mdx
@@ -11,8 +11,8 @@ Dolomite streamlines the decentralized exchange experience so that users can uti
 
 An ethereum node is required in order to use Hummingbot with Dolomite. Luckily, an Ethereum node is only needed for approving tokens, which is a one-time process. So, users of the Dolomite connector can rest assured it will add virtually no extra stress to their node. See below for information on how to create an Ethereum node and wallet:
 
-- [Creating a crypto wallet](/advanced/wallet)
-- [Creating an ethereum node](/advanced/node)
+- [Creating a crypto wallet](/operation/adv-command-ref/#setup-ethereum-wallet)
+- [Creating an ethereum node](/operation/adv-command-ref/#setup-ethereum-nodes)
 
 In addition to the above, the user must also create an account on Dolomite. As of now, this takes 1 of 2 forms:
 

--- a/content/connectors/eterbase.mdx
+++ b/content/connectors/eterbase.mdx
@@ -103,4 +103,4 @@ Rule with attributes values `Qty` and `Min` denotes the minimum order size for e
 
 Eterbase charges 0.35% in both maker and taker fees for basic tier. However, users with deposited XBASE tokens can trade at discounted rates. Refer to [Eterbase Trading Fees](https://www.eterbase.com/exchange/fees/) section for more details.
 
-Users can override the default fees by editing [`conf_fee_overrides.yml`](https://docs.hummingbot.io/advanced/fee-overrides/).
+Users can override the default fees by editing [`conf_fee_overrides.yml`](https://docs.hummingbot.io/operation/adv-command-ref/#fee-override).

--- a/content/connectors/radar-relay.mdx
+++ b/content/connectors/radar-relay.mdx
@@ -9,8 +9,8 @@ description: About Radar Relay Connector
 
 Because Radar Relay is a decentralized exchange, you will need an independent cryptocurrency wallet and an ethereum node in order to use Hummingbot. See below for information on how to create these:
 
-* [Creating a crypto wallet](/advanced/wallet)
-* [Creating an ethereum node](/advanced/node)
+* [Creating a crypto wallet](/operation/adv-command-ref/#setup-ethereum-wallet)
+* [Creating an ethereum node](/operation/adv-command-ref/#setup-ethereum-nodes)
 
 ## Miscellaneous Info
 

--- a/content/operation/adv-command-ref.mdx
+++ b/content/operation/adv-command-ref.mdx
@@ -199,7 +199,7 @@ the oldest ones will be deleted in order to limit disk storage usage.
 The log rotation feature was added in [Hummingbot version 0.17.0](https://docs.hummingbot.io/release-notes/0.17.0/#log-file-management-data-storage).
 
 If you are looking for support in handling errors or have questions about behavior reported in logs,
-you can find ways of contacting the team or community in our [support section](/support).
+you can find ways of contacting the team or community in our [support section](/intro/support).
 
 ## Setup Ethereum wallet
 

--- a/content/operation/client.mdx
+++ b/content/operation/client.mdx
@@ -29,9 +29,9 @@ For additional information on useful commands, see the [commands](/operation/com
 - API Keys: In order to run a bot on a centralized exchange like Binance, you will need to enter the exchange API keys during the Hummingbot configuration process.
   For more information on how to get the API keys for each exchange, please see the individual exchange pages in [Connectors](/connectors/overview).
 - Ethereum Wallet: In order to earn rewards from Liquidity Bounties, you need an Ethereum wallet. In addition, you'll need to import an Ethereum wallet when you run a trading bot on an Ethereum-based decentralized exchange.
-  For more information on creating or importing an Ethereum wallet, see [Ethereum wallet](/operation/adv-command-ref).
+  For more information on creating or importing an Ethereum wallet, see [Ethereum wallet](/operation/adv-command-ref/#setup-ethereum-wallet).
 - Ethereum Node (DEX only): When you run a trading bot on a Ethereum-based decentralized exchange, your wallet sends signed transactions to the blockchain via an Ethereum node.
-  For more information, see [Ethereum node](/operation/adv-command-ref).
+  For more information, see [Ethereum node](/operation/adv-command-ref/#setup-ethereum-nodes).
 
 > **Note:** Make sure that you activate the Anaconda environment with `conda activate hummingbot` prior to running Hummingbot.
 
@@ -104,7 +104,7 @@ When running `create`, you are asked to select a strategy and enter strategy-spe
 - [Cross-exchange market making](/strategies/cross-exchange-market-making)
 - [Pure market making](/strategies/pure-market-making)
 
-> **Note:** When configuring your bot, make sure you are aware of your exchange's minimum order sizes and fees, and check that your trading pair has sufficient order book and trading volumes. You can find more info about specific exchanges in the [Connectors](/connectors) section.
+> **Note:** When configuring your bot, make sure you are aware of your exchange's minimum order sizes and fees, and check that your trading pair has sufficient order book and trading volumes. You can find more info about specific exchanges in the [Connectors](/connectors/overview) section.
 
 ## API keys
 

--- a/content/operation/command-ref.mdx
+++ b/content/operation/command-ref.mdx
@@ -514,7 +514,7 @@ Trade Value Delta = -0.47357
 
 Return is calculated based on assets spent and acquired during trades, i.e. balance changes due to the inventory like deposits, withdrawals, and manual trades outside of Hummingbot do not affect the calculation.
 
-$Return\ \% = trade\_value\_delta / starting\_quote\_value$
+$Return % = trade\_value\_delta / starting\_quote\_value$
 
 ```
 Inventory:

--- a/content/resources/liquidity-mining.mdx
+++ b/content/resources/liquidity-mining.mdx
@@ -132,7 +132,7 @@ In most cases and for most assets, you can use a Binance deposit address to rece
 
 > **Note**:
 There are exceptions where the rewards assets may not be supported by a Binance deposit address. Make sure to review the terms of each campaign carefully.
-For example, the USDT ASA rewards asset for the Algorand is not currently supported on Binance.
+For example, the USDT ASA rewards asset for the Algorand campaign is not currently supported on Binance.
 
 1. Navigate to Binance Spot wallet
 2. Click the **Deposit** button and choose the token you want to get the address. 


### PR DESCRIPTION
Sample broken links:
(Bamboo,Radar, and Dolomite)
![image](https://user-images.githubusercontent.com/57189990/97065509-68cc2900-15e0-11eb-97c3-1e6f5c8a8dab.png)
