### PR TITLE
question on the demo lines

### DIFF
--- a/content/strategies/filled-order-delay.mdx
+++ b/content/strategies/filled-order-delay.mdx
@@ -125,10 +125,10 @@ Orders:
 Notice the timestamps. Since the refresh time is longer than the filled order delay, the unfilled order will remain active until it's time to create new sets of orders.
 
 ```
-00:01:09 - (BTCUSDT) Cancelling the buy limit order
+00:01:10 - (BTCUSDT) Creating 1 ask order at ['0.005 BTC, 9090.128 USDT']
 ```
 
 ```
-00:01:10 - (BTCUSDT) Creating 1 bid order at ['0.005 BTC, 9047.709 USDT']
-00:01:10 - (BTCUSDT) Creating 1 ask order at ['0.005 BTC, 9093.266 USDT']
+00:02:09 - (BTCUSDT) Cancelling the buy limit order
+00:02:10 - (BTCUSDT) Creating 1 bid order at ['0.005 BTC, 9044.749 USDT']
 ```


### PR DESCRIPTION
as the order_refresh_time is 120.0, shouldn't it cancel and recreate the buy limit order after 120s?