### PR TITLE
Docs / release notes broken link fix

### DIFF
--- a/content/release-notes/0.28.0.mdx
+++ b/content/release-notes/0.28.0.mdx
@@ -11,11 +11,11 @@ In order to communicate the status of bug fixes and planned improvements, we rec
 
 We are excited to release a Hummingbot connector for Celo blockchain and exchange. Celo is a new Layer 1 protocol that relies upon arbitrageurs to maintain the peg on their cUSD stablecoin. Now, you can run the new `celo-arb` strategy to help stabilize their token price while arbitraging differences between centralized exchanges and the Celo blockchain.
 
-For more information, see the [celo-arb strategy page](/strategies/celo-arb) and the [Celo quickstart guide](/strategies/celo-arb/quickstart).
+For more information, see the [celo-arb strategy page](/strategies/celo-arb) and the [Celo quickstart guide](/strategies/celo-arb/#setup).
 
 ## 🏓 New parameter: ping_pong
 
-We introduce a new parameter that allow your bot to alternate placing buy and sell orders, a simple way to keep your inventory levels constant. For more information, please see the [ping pong documentation page](/strategies/advanced-mm/ping-pong).
+We introduce a new parameter that allow your bot to alternate placing buy and sell orders, a simple way to keep your inventory levels constant. For more information, please see the [ping pong documentation page](/strategies/ping-pong/).
 
 **We want to thank 🙏 community member [petrioptrv](https://github.com/petioptrv) for this contribution!**
 
@@ -31,7 +31,7 @@ _Note: Assets listed in the `balance` command are now listed in alphabetical ord
 
 ## ☝️ Trade notifications
 
-When the Hummingbot client makes a trade, it now appends a trade notification message to the lefthand output screen. Users of the [Telegram integration](/advanced/telegram/) should also see these notifications in the Telegram interface.
+When the Hummingbot client makes a trade, it now appends a trade notification message to the lefthand output screen. Users of the [Telegram integration](/operation/telegram/) should also see these notifications in the Telegram interface.
 
 ## 🐞 Other Enhancements and Fixes
 

--- a/content/release-notes/0.28.1.mdx
+++ b/content/release-notes/0.28.1.mdx
@@ -7,7 +7,7 @@ This release is a hotfix to version [0.28.0](/release-notes/0.28.0).
 ## Enhancements
 
 - Added a [fix (#1868)](https://github.com/CoinAlpha/hummingbot/pull/1868) for an [enhancement (#1669)](https://github.com/CoinAlpha/hummingbot/issues/1669) to enter negative values for the `order_level_amount` parameter.
-- Added a [fix (#1869)](https://github.com/CoinAlpha/hummingbot/pull/1869) for an [enhancement (#1752)](https://github.com/CoinAlpha/hummingbot/issues/1752) to set different bid and ask depth for [order optimization](/strategies/advanced-mm/order-optimization/).
+- Added a [fix (#1869)](https://github.com/CoinAlpha/hummingbot/pull/1869) for an [enhancement (#1752)](https://github.com/CoinAlpha/hummingbot/issues/1752) to set different bid and ask depth for [order optimization](/strategies/order-optimization/).
 
 ## Bug fixes
 

--- a/content/release-notes/0.29.0.mdx
+++ b/content/release-notes/0.29.0.mdx
@@ -6,7 +6,7 @@ title: "Version 0.29.0"
 
 ## 🤖 New feature: Scripts
 
-The new Scripts feature allows the user to create mini-Python functions that adjust how Hummingbot behaves. For example, users can automate changes to bot params when certain conditions are met. Read more about the scripts feature in the [Scripts](/advanced/scripts/) section in the documentation.
+The new Scripts feature allows the user to create mini-Python functions that adjust how Hummingbot behaves. For example, users can automate changes to bot params when certain conditions are met. Read more about the scripts feature in the [Scripts](/scripts/script-base/#scriptbase) section in the documentation.
 
 !!! warning
 Currently, Scripts can only be used when running Hummingbot from source or with Docker. Using this feature in the Mac or Windows installers will crash the bot.

--- a/content/release-notes/0.30.0.mdx
+++ b/content/release-notes/0.30.0.mdx
@@ -10,17 +10,17 @@ As described in feature request [#1443](https://github.com/CoinAlpha/hummingbot/
 
 This command is useful when running multiple bots sharing the same assets in an account e.g. setting a 50% USDT limit to each bot running BTC-USDT and ETH-USDT pair.
 
-Run the command `balance limit [exchange] [asset] [amount]` to do this. More information in [balance command](/operation/commands/balance/#balance-limit-exchange-asset-amount).
+Run the command `balance limit [exchange] [asset] [amount]` to do this. More information in [balance command](/operation/command-ref/#balance).
 
 ## 📜 New command: Balance Paper
 
 Adding paper trade balances can now be done easier from the Hummingbot client by running `balance paper [asset] [amount]`. Also, users can now check paper trading account balances by running `balance paper` command.
 
-For more information and sample usage, refer to [balance command](/operation/commands/balance/#balance-paper) in our documentation.
+For more information and sample usage, refer to [balance command](/operation/command-ref/#balance) in our documentation.
 
 ## 📖 New command: Order Book
 
-Users can now see the market's order book by running the [order_book](/operation/commands/order_book) command from the Hummingbot CLI while a strategy is running.
+Users can now see the market's order book by running the [order_book](/operation/command-ref/#order_book) command from the Hummingbot CLI while a strategy is running.
 
 By default, this command shows the top 5 bid/ask prices with order volume. It can be used with optional arguments like `--lines` to specify the number of lines to show, `--markets` and `--exchange` if running on cross-exchange and arbitrage strategy.
 


### PR DESCRIPTION
Fixed links on release versions:
v.0.30.0
v.0.29.0
v.0.28.1
v.0.28.0

![image](https://user-images.githubusercontent.com/71769411/97956616-1ced6100-1de4-11eb-9055-d176c0fd8622.png)