### PR TITLE
docs/fix_documentation_links added link for ticker, orderbook and status 

### DIFF
--- a/content/release-notes/0.33.0.mdx
+++ b/content/release-notes/0.33.0.mdx
@@ -19,9 +19,9 @@ Documentation has been revamped into two sites:
 
 [#2519](https://github.com/CoinAlpha/hummingbot/pull/2519): This new arguement displays live updates for the following commands:
 
-- ticker, see sample usage in our [documentation](operation/command-ref/#ticker)
-- orderbook, see sample usage in our [documentation](/operation/commands/#orderbook)
-- status, see sample usage in our [documentation](/operation/commands/#status)
+- ticker, see sample usage in our [documentation](/operation/command-ref/#ticker)
+- orderbook, see sample usage in our [documentation](/operation/command-ref/#order_book)
+- status, see sample usage in our [documentation](/operation/command-ref/#status)
 
 ## 🔗 Connectors
 


### PR DESCRIPTION
(docs) Added documentation links for ticker, orderbook (order_book) and status