### PR TITLE
docs / fix broken links release notes

### DIFF
--- a/content/release-notes/0.33.0.mdx
+++ b/content/release-notes/0.33.0.mdx
@@ -6,14 +6,13 @@ title: "Version 0.33.0"
 
 We are excited to release Balancer AMM Arb strategy. For more information, see the [Balancer Arb strategy page](/strategies/balancer-arb).
 
-
 ## 📊 New argument [--live]
 
 [#2519](https://github.com/CoinAlpha/hummingbot/pull/2519): This new arguement displays live updates for the following commands:
 
-- ticker, see sample usage in our [documentation](operation/command-ref/#ticker)
-- orderbook, see sample usage in our [documentation](/operation/commands/#orderbook)
-- status, see sample usage in our [documentation](/operation/commands/#status)
+- ticker, see sample usage in our [documentation](/operation/command-ref/#ticker)
+- orderbook, see sample usage in our [documentation](/operation/command-ref/#order_book)
+- status, see sample usage in our [documentation](/operation/command-ref/#status)
 
 ## 🔗 Connectors
 
@@ -27,8 +26,8 @@ The following connectors are now supported:
 ## 🔄 UI/UX Enhancements
 
 - [#2430](https://github.com/CoinAlpha/hummingbot/issues/2430): Additional connector status column display when using `connect` command. Also, you can view the connector status in the [readme](https://github.com/CoinAlpha/hummingbot/blob/master/README.md) file.
-- [#2179](https://github.com/CoinAlpha/hummingbot/issues/2179): The Hummingbot client top and bottom navbars are enhanced with usage information, see [User Interface](operation/client/#user-interface) for details.
-- [#2129](https://github.com/CoinAlpha/hummingbot/issues/2129): The `history` command is redesigned with more information and additional arguments, see [History](operation/command-ref/#history) for details.
+- [#2179](https://github.com/CoinAlpha/hummingbot/issues/2179): The Hummingbot client top and bottom navbars are enhanced with usage information, see [User Interface](/operation/client/#user-interface) for details.
+- [#2129](https://github.com/CoinAlpha/hummingbot/issues/2129): The `history` command is redesigned with more information and additional arguments, see [History](/operation/command-ref/#history) for details.
 
 ## 💻 Developers Updates
 


### PR DESCRIPTION
- fix broken links release notes 0.33.0

![image](https://user-images.githubusercontent.com/54516858/98806441-2dd94a80-2454-11eb-92c1-fb8986802978.png)
