### PR TITLE
Doc/fix_notes

### DIFF
--- a/content/strategies/amm-arb.mdx
+++ b/content/strategies/amm-arb.mdx
@@ -60,7 +60,7 @@ The following sections describes the installation and configuration process for 
     Enter passphrase to generate Gateway SSL certification >>>
    ```
 
-3. Enter a passphrase.**Note:**
+3. Enter a passphrase. **Note:**
    - It is recommended not to use the same password as the Hummingbot instance.
    - Take note of the passphrase and cert path to be use later for Gateway Docker settings.
 

--- a/content/strategies/perpetual-market-making.mdx
+++ b/content/strategies/perpetual-market-making.mdx
@@ -50,7 +50,7 @@ Enter the leverage you would like to use.
 <div style={{ padding: "10px 20px", backgroundColor: "#1c1c1c" }}>
   <font color="#20a26a">
     How much leverage do you want to use? (Binance Perpetual supports up to 75X
-    for most pairs))>>>{" "}
+    for most pairs)>>>{" "}
   </font>
 </div>
 


### PR DESCRIPTION
(doc) added space between "passphrase" and "Note" on #create SSL Cert in Hummingbot in _https://docs.hummingbot.io/strategies/amm-arb/_

(doc) remove extra ) on #Leverage prompt  in _https://docs.hummingbot.io/strategies/perpetual-market-making/_