### PR TITLE
docs / fixed the link and rerouted to "new-command-balance-limit"

### DIFF
--- a/content/strategies/inventory-skew.mdx
+++ b/content/strategies/inventory-skew.mdx
@@ -106,7 +106,7 @@ By decreasing the range multiplier to 0.5, the target range tightens (29.4% to 7
 
 ### Inventory Skew with Balance Limit
 
-Starting with version **0.30.0**, a [limit](https://docs.hummingbot.io/operation/commands/balance/#balance-limit-exchange-asset-amount) can be applied to the total balance to allocate how much the bot can access in an exchange or wallet. With inventory skew, Hummingbot will maintain a target balance with respect to the allowable asset.
+Starting with version **0.30.0**, a [limit](/release-notes/0.30.0/#-new-command-balance-limit) can be applied to the total balance to allocate how much the bot can access in an exchange or wallet. With inventory skew, Hummingbot will maintain a target balance with respect to the allowable asset.
 
 ```json
 - inventory_skew_enabled: True


### PR DESCRIPTION
Rerouted the link to /release-notes/0.30.0/#-new-command-balance-limit
- so user can see the update on 0.30.0 regarding the balance limit
- so user can check the link to balance commands where it shows the "balance limit [ exchange ][ asset ] [ amount ]" notes