### PR TITLE
doc / fix broken links on version 0.25.0

### DIFF
--- a/content/release-notes/0.25.0.mdx
+++ b/content/release-notes/0.25.0.mdx
@@ -35,7 +35,7 @@ See the new [Advanced Market Marketing](/strategies/adv-market-making/) section 
 
 We changed the inventory skew algorithm to a better behaved one to limit the user's trading exposure within a defined range. This prevents users from being over-exposed from the risks of a single side of the trade when the market keeps hitting limit orders on one side only.
 
-More information can be found in our documentation for [Inventory Skew](/strategies/advanced-mm/inventory-skew) with sample scenarios.
+More information can be found in our documentation for [Inventory Skew](/strategies/inventory-skew/) with sample scenarios.
 
 ### Hanging orders
 

--- a/content/release-notes/0.25.0.mdx
+++ b/content/release-notes/0.25.0.mdx
@@ -29,7 +29,7 @@ We made some changes to how bot `status` is displayed to make it more informativ
 
 Due to the extreme market volatility in the last 2 weeks, many users have reporting losing money due to market swings. In this release, we have made major improvements to advanced market making features. We believe that these features will enable users to configure their bots so that they respond better to market volatility.
 
-See the new [Advanced Market Marketing](/strategies/advanced-mm) section to learn more about how these features work. We have described the main changes below.
+See the new [Advanced Market Marketing](/strategies/adv-market-making/) section to learn more about how these features work. We have described the main changes below.
 
 ### Inventory skew
 

--- a/content/release-notes/0.25.0.mdx
+++ b/content/release-notes/0.25.0.mdx
@@ -41,7 +41,7 @@ More information can be found in our documentation for [Inventory Skew](/strateg
 
 Hanging orders are now tracked as active orders when sending the `status` command. These orders will get cancelled after sending the `stop` or `exit` command. Also, users can now specify through `cancel_hanging_order_pct` to cancel hanging orders when their spreads are above a certain value.
 
-Read through [Hanging Orders](/strategies/advanced-mm/hanging-orders) in our documentation for more information.
+Read through [Hanging Orders](/strategies/hanging-orders/) in our documentation for more information.
 
 ### Safer defaults
 


### PR DESCRIPTION
Fix broken links for Advance market making, Inventory Skew and Hanging orders on /release-notes/0.25.0/