### PR TITLE
doc / fix broken links for release-notes 19, 18, 17, 16, 14 and 13

### DIFF
--- a/content/release-notes/0.13.0.mdx
+++ b/content/release-notes/0.13.0.mdx
@@ -21,7 +21,7 @@ Refactored block watchers and web3 wallet modules to materially reduce the numbe
 
 As part of our ongoing efforts to make the Hummingbot code base more understandable and easier to use for developers, 0.13.0 includes quite a bit of new explanations and documentation:
 
-- Developer documentation for [cross exchange market making](/developers/strategies/cross-exchange-market-making/)
+- Developer documentation for [cross exchange market making](/developer/cross-exchange-market-making/)
 - Developer documentation for [adding exchange connectors](/developers/connectors/)
 - Extensive comments in the strategy code files: [arbitrage](https://github.com/CoinAlpha/hummingbot/tree/master/hummingbot/strategy/arbitrage), [cross exchange market making](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/strategy/cross_exchange_market_making), and discovery
 

--- a/content/release-notes/0.14.0.mdx
+++ b/content/release-notes/0.14.0.mdx
@@ -18,7 +18,7 @@ Hummingbot now support [Huobi Global](https://www.hbg.com)! You can read more ab
 
 Our efforts to make the Hummingbot code base more understandable and easier to use for developers continues, with additional documentation for strategies:
 
-- Developer documentation for [arbitrage strategy](/developers/strategies/arbitrage/).
+- Developer documentation for [arbitrage strategy](/developer/arbitrage/).
 - Developer documentation for discovery strategy.
 
 ## 🐞 Other bug fixes and miscellaneous updates

--- a/content/release-notes/0.16.0.mdx
+++ b/content/release-notes/0.16.0.mdx
@@ -14,21 +14,21 @@ We will keep the rewards schedule the same for October.
 
 After you have placed an order, have you seen other orders respond by making their price slightly better than yours? This is called penny-jumping, and it can be a good way to ensure that your orders have the highest probability of being filled while maximizing the profit upon a fill.
 
-With pure market making strategy (in single order mode), users now have the option to automatically adjust the prices to just above top bid and just below top ask. See [this page](https://docs.hummingbot.io/strategies/advanced-mm/order-optimization/) for more information.
+With pure market making strategy (in single order mode), users now have the option to automatically adjust the prices to just above top bid and just below top ask. See [this page](/strategies/order-optimization/) for more information.
 
 ## 💵 Transaction costs in **pure_market_making** strategy
 
 We have conformed how transaction costs are handled across all strategies. By default, the pure market making strategy now incorporates transaction costs like exchange trading fees and gas costs into order prices.
 
-This is a configurable parameter, so users can turn this behavior off if they like. See [this page](https://docs.hummingbot.io/strategies/advanced-mm/add-transaction-costs/).
+This is a configurable parameter, so users can turn this behavior off if they like. See [this page](/strategies/add-transaction-costs/).
 
 ## 📝 More developer documentation
 
 As part of our ongoing efforts to make the Hummingbot code base more understandable and easier to use for developers, we have published guidelines for community-contributed exchange connectors, as well as more documentation on the order lifecycle:
 
-- [Guidelines and expectations for community developers building exchange connectors](https://docs.hummingbot.io/developers/connectors/order-lifecycle/)
-- [Order lifecycle and market events for connectors](https://docs.hummingbot.io/developers/strategies/#creating-and-cancelling-orders)
-- [Changed MarketSymbolPair to MarketTradingPairTuple in strategies for creating and cancelling orders](https://docs.hummingbot.io/developers/strategies/#creating-and-cancelling-orders)
+- [Guidelines and expectations for community developers building exchange connectors](/developer/tutorial/#order-lifecycle-flowchart)
+- [Order lifecycle and market events for connectors](/developer/tutorial/#order-lifecycle-and-market-events)
+- [Changed MarketSymbolPair to MarketTradingPairTuple in strategies for creating and cancelling orders](/developer/strategies-overview/#creating-and-cancelling-orders)
 
 ## 🐞 Other bug fixes and miscellaneous updates
 

--- a/content/release-notes/0.17.0.mdx
+++ b/content/release-notes/0.17.0.mdx
@@ -18,13 +18,13 @@ We redesigned how Hummingbot analyzes performance so that events unrelated to Hu
 
 We published a developer tutorial on building custom strategies and documentation for the **Perform Trade** strategy.
 
-- [Developer Tutorial](https://docs.hummingbot.io/developers/tutorial/)
-- [Perform Trade Strategy](https://docs.hummingbot.io/developers/tutorial/perform-trade/)
+- [Developer Tutorial](/developer/tutorial/#building-connectors)
+- [Perform Trade Strategy](/developer/build-strategy/#perform-trade-strategy)
 
 ## 📚Log file management / data storage
 
 - A separate log file will now be generated daily. When a new log file is created, if there are more than 7 files, the oldest ones will be deleted in order to limit disk storage usage.
-- AWS free tier provides 7.7GB of disk space. Ubuntu files take about 1.1 GB, Docker takes about 0.4 GB, and hummingbot image takes about 2.5 GB. This leaves about 3.7 GB for the logs and data files, which should be enough, especially now that we have set up log rotation. Refer to [Amazon Web Services](https://docs.hummingbot.io/installation/cloud/#amazon-web-services) section under Setup a Cloud Server in User Manual.
+- AWS free tier provides 7.7GB of disk space. Ubuntu files take about 1.1 GB, Docker takes about 0.4 GB, and hummingbot image takes about 2.5 GB. This leaves about 3.7 GB for the logs and data files, which should be enough, especially now that we have set up log rotation. Refer to [Amazon Web Services](/installation/overview/#for-cloud) section under Setup a Cloud Server in User Manual.
 
 ## 🐞 Other bug fixes and miscellaneous updates
 

--- a/content/release-notes/0.18.0.mdx
+++ b/content/release-notes/0.18.0.mdx
@@ -23,7 +23,7 @@ Follow the links below for more information:
 
 ## 🤓 Developer usability
 
-- Developer documentation for [Simple Trade](https://docs.hummingbot.io/developers/tutorial/simple-trade/)
+- Developer documentation for [Simple Trade](/developer/build-strategy/#simple-trade-strategy)
 - Added missing templates for dev strategies: [#960](https://github.com/CoinAlpha/hummingbot/pull/960)
 
 ## 🐞 Other bug fixes and miscellaneous updates

--- a/content/release-notes/0.19.0.mdx
+++ b/content/release-notes/0.19.0.mdx
@@ -15,8 +15,8 @@ title: "Version 0.19.0"
 ## 🤓 Developer usability
 
 - Tutorial for creating custom strategies now has its own dedicated section. It is currently a work-in-progress but you can check out the initial parts [here](/developers/tutorial).
-- [Architecture](/developers/connectors/architecture) section that includes additional details for adding new connectors.
-- Added detailed examples to [Building Connectors](/developers/connectors/tutorial) in using aioconsole for testing.
+- [Architecture](/developer/architecture/) section that includes additional details for adding new connectors.
+- Added detailed examples to [Building Connectors](/developer/tutorial/) in using aioconsole for testing.
 
 ## 🐞 Other bug fixes and miscellaneous updates
 


### PR DESCRIPTION
Fix broken links on the following :
**/release-notes/0.19.0/**
Architecture
Building connectors

**/release-notes/0.18.0/**
Simple trade

**/release-notes/0.17.0/**
Developer Tutorial
Perform Trade Strategy
Amazon Web Services

**/release-notes/0.16.0/**
this page (Order Optimization)
this page (Adding Transaction Cost)
Guidelines and expectations for community developers building exchange connectors
Order lifecycle and market events for connectors
Changed MarketSymbolPair to MarketTradingPairTuple in strategies for creating and cancelling orders

**/release-notes/0.14.0/**
Arbitrage strategy

**/release-notes/0.13.0/**
Cross Exchange Market Making