### PR TITLE
doc / fix broken links and Tip

### DIFF
--- a/content/release-notes/0.10.0.mdx
+++ b/content/release-notes/0.10.0.mdx
@@ -10,7 +10,7 @@ A number of users have reported seeing duplicate orders when running the pure ma
 
 ## 📝 Improved docs: Quickstart, helper scripts, and more!
 
-As part of an ongoing process to improve Hummingbot's documentation, we have re-organized the layout of our docs, added helper scripts to make using the Docker image version easier, and created a new [Quickstart guide](/quickstart) to simplify the new user experience.
+As part of an ongoing process to improve Hummingbot's documentation, we have re-organized the layout of our docs, added helper scripts to make using the Docker image version easier, and created a new [Quickstart guide](https://hummingbot.io/academy/quickstart/) to simplify the new user experience.
 
 ## 🛑 Renamed stop loss to kill switch
 

--- a/content/release-notes/0.11.0.mdx
+++ b/content/release-notes/0.11.0.mdx
@@ -18,7 +18,7 @@ Over time, we will add more content to the other sections.
 
 ![](/assets/img/simple_trade.png)
 
-We added a new strategy: [Simple Trade](https://docs.hummingbot.io/developers/tutorial/simple-trade/).
+We added a new strategy: [Simple Trade](/developer/build-strategy/#simple-trade-strategy).
 
 This strategy gives users a starter template upon which to customize their own strategies.
 

--- a/content/release-notes/0.12.0.mdx
+++ b/content/release-notes/0.12.0.mdx
@@ -8,7 +8,7 @@ title: "Version 0.12.0"
 
 The pure market making strategy now includes a feature that modifies the size of your bid/ask orders in order to maintain a target ratio of base to quote asset. For example, if you are trading ETH-USDT and are targeting a 50%/50% ratio of ETH to USDT, if the value of your ETH holdings accounts for more than 50% of your current portfolio, the bid (buy ETH) size will be reduced while the ask (sell ETH) size will be increased.
 
-Read more about this feature [here](https://docs.hummingbot.io/strategies/advanced-mm/inventory-skew/).
+Read more about this feature [here](/strategies/inventory-skew/).
 
 ## 🐞 Other bug fixes and miscellaneous updates
 

--- a/content/release-notes/0.13.0.mdx
+++ b/content/release-notes/0.13.0.mdx
@@ -22,7 +22,7 @@ Refactored block watchers and web3 wallet modules to materially reduce the numbe
 As part of our ongoing efforts to make the Hummingbot code base more understandable and easier to use for developers, 0.13.0 includes quite a bit of new explanations and documentation:
 
 - Developer documentation for [cross exchange market making](/developer/cross-exchange-market-making/)
-- Developer documentation for [adding exchange connectors](/developers/connectors/)
+- Developer documentation for [adding exchange connectors](/developer/miscellaneous/#adding-connectors-to-exchanges-on-other-blockchains)
 - Extensive comments in the strategy code files: [arbitrage](https://github.com/CoinAlpha/hummingbot/tree/master/hummingbot/strategy/arbitrage), [cross exchange market making](https://github.com/CoinAlpha/hummingbot/blob/master/hummingbot/strategy/cross_exchange_market_making), and discovery
 
 ## 💻 Autostart a strategy on launch with new CLI launch commands

--- a/content/release-notes/0.27.0.mdx
+++ b/content/release-notes/0.27.0.mdx
@@ -6,7 +6,7 @@ title: "Version 0.27.0"
 
 We're also starting to see more external contributions from the Hummingbot community. See [Community](/community) for more information on how to contribute to Hummingbot.
 
-!!! tip "Introducing the Hummingbot Public Roadmap"
+> **Tip:** "Introducing the Hummingbot Public Roadmap"
 In order to communicate the status of bug fixes and planned improvements, we recently began to publish the [Hummingbot Public Roadmap](https://github.com/CoinAlpha/hummingbot/projects/2). We will keep this page updated, so please bookmark this page to see the newest updates to the Hummingbot codebase.
 
 ## 🔄 Order Refresh Tolerance

--- a/content/release-notes/0.9.0.mdx
+++ b/content/release-notes/0.9.0.mdx
@@ -24,7 +24,7 @@ Today, we're happy to announce that the IDEX market connector is ready for use, 
 
 The [pure market making strategy](/strategies/pure-market-making/) now allows you to place multiple levels of orders on each side of the order book. This allows market makers to set different tiers of orders with different spreads and order amounts.
 
-For information on how to use this new feature, please see the [Multiple Orders configuration](https://docs.hummingbot.io/strategies/advanced-mm/multiple-orders/) section.
+For information on how to use this new feature, please see the [Multiple Orders configuration](/strategies/order-levels/) section.
 
 ## 📈 Performance analysis in `history` command
 


### PR DESCRIPTION
- fix UI tip from /release-notes/0.27.0/
- update link for here (inventory skew) on  /release-notes/0.12.0/
- update link for "Adding Exchange Connector" for /release-notes/0.11.0/\
- update link for Simple Trade on /release-notes/0.11.0/
- update link for Quickstart guide on /release-notes/0.10.0/
- update link for Multiple orders configuration on /release-notes/0.9.0/