### PR TITLE
doc / checking typo

### DIFF
--- a/content/strategies/external-price-source.mdx
+++ b/content/strategies/external-price-source.mdx
@@ -63,8 +63,7 @@ price_source_custom_api: None
 
 Run `config price_type` command to change the price reference to `last_price`, `last_own_trade_price`, `best_bid`, and `best_ask`. The parameter `take_if_crossed` is optional as this only allows users to take existing orders from the order book if there is an existing match.
 
-!!! note
-    Currently, the external price source cannot be the same as the maker exchange (i.e. if the bot is trading on Binance, the `price_source_exchange` cannot be Binance).
+> **Note** : Currently, the external price source cannot be the same as the maker exchange (i.e. if the bot is trading on Binance, the `price_source_exchange` cannot be Binance).
 
 ### Price Source: Custom API
 

--- a/content/strategies/overview.mdx
+++ b/content/strategies/overview.mdx
@@ -17,7 +17,7 @@ Also referred to as _liquidity mirroring_ or _exchange remarketing_. In this str
 
 ### Binance Perpertual Market Making
 
-Similar to pure market maing but with more risks in terms of leverage up to x75.
+Similar to pure market making but with more risks in terms of leverage up to x75.
 
 ### Arbitrage
 

--- a/content/strategies/overview.mdx
+++ b/content/strategies/overview.mdx
@@ -15,7 +15,7 @@ For experienced users of this strategy, see [Advanced Market Making](adv-market-
 
 Also referred to as _liquidity mirroring_ or _exchange remarketing_. In this strategy, Hummingbot makes markets (creates buy and sell orders) on smaller or less liquid exchanges and does the opposite, back-to-back transaction for any filled trades on a more liquid exchange.
 
-### Binance Perpertual Market Making
+### Binance Perpetual Market Making
 
 Similar to pure market making but with more risks in terms of leverage up to x75.
 


### PR DESCRIPTION
- fix typo on content/strategies/overview.mdx 
- fix "note" on content/strategies/external-price-source.mdx