### PR TITLE
docs / false positives on binary installers

### DIFF
--- a/content/intro/support.mdx
+++ b/content/intro/support.mdx
@@ -325,6 +325,17 @@ Copying encrypted Binance key file from Instance1 to Instance2 will result to th
 2. Restart Hummingbot and password 5678 remains unchanged
 3. Run `connect binance` and add the API keys - this will encrypt it with 5678 password and sync it with the rest of the API keys
 
+### Why does my anti-virus software flag Hummingbot's binary installer?
+
+This has been reported by some users starting from version 0.33 (see [GitHub issue #2680](https://github.com/CoinAlpha/hummingbot/issues/2680)).
+
+The two AV engines that give a positive reading are Gridinsoft and Cyren. They both have methods of submitting false positives:
+
+https://blog.gridinsoft.com/how-to-report-the-false-detection/
+https://www.cyren.com/support/reporting-av-misclassifications
+
+We believe these are fairly generic designations that are probably triggered by the general crypto code in the `ethsnarks` module for the Loopring connector.
+
 ## Miscellaneous
 
 ### How do I resize my Hummingbot window without jumbling the text?


### PR DESCRIPTION
Added explanation to FAQ for the AV engines that submits false positives.

![image](https://user-images.githubusercontent.com/50150287/101459993-f2a73a00-3973-11eb-93c2-f52de619b611.png)
