### PR TITLE
docs/ removed broken links in advanced config of PMM

### DIFF
--- a/content/developer/pure-market-making.mdx
+++ b/content/developer/pure-market-making.mdx
@@ -23,27 +23,27 @@ There are a few plugin interfaces that the pure market making strategy depends o
 
 ![Figure 6: Pure market making strategy plugins](/img/pure-mm-uml.svg)
 
-- [`OrderFilterDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_filter_delegate.pxd)
+- OrderFilterDelegate
 
   Makes the Yes / No decision to proceed with processing the current clock tick or not.
 
-- [`OrderPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_pricing_delegate.pxd)
+- OrderPricingDelegate
 
-  Returns a [`PriceProposal`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/data_types.py) with lists of prices for creating bid and ask orders. If no order should be created at the current clock tick (e.g. because there're already existing orders), it may choose to return empty lists instead.
+  Returns a PriceProposal with lists of prices for creating bid and ask orders. If no order should be created at the current clock tick (e.g. because there're already existing orders), it may choose to return empty lists instead.
 
-- [`OrderSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/order_sizing_delegate.pxd)
+- OrderSizingDelegate
 
-  Returns a [`SizingProposal`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/data_types.py) with lists of order sizes for creating bid and ask orders, given the pricing proposal. If a proposed order at a certain price should not be created (e.g. there's not enough balance on the exchange), it may choose to return zero size for that order instead.
+  Returns a SizingProposal with lists of order sizes for creating bid and ask orders, given the pricing proposal. If a proposed order at a certain price should not be created (e.g. there's not enough balance on the exchange), it may choose to return zero size for that order instead.
 
 ## Built-in Plugins
 
-If you configure the pure market making strategy with the `order_levels` parameter set to 1, then Hummingbot will use [`ConstantSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_spread_pricing_delegate.pyx) and [`ConstantSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_size_sizing_delegate.pyx) for the pricing and sizing plugins.
+If you configure the pure market making strategy with the `order_levels` parameter set to 1, then Hummingbot will use ConstantSpreadPricingDelegat for the pricing and sizing plugins.
 
-Alternatively, setting `order_levels` greater than 1 places multiple levels of orders of each side of the order book. In this case, Hummingbot will use [`ConstantMultipleSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_multiple_spread_pricing_delegate.pyx) and [`StaggeredMultipleSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/staggered_multiple_size_sizing_delegate.pyx) for the pricing and sizing plugins instead.
+Alternatively, setting `order_levels` greater than 1 places multiple levels of orders of each side of the order book. In this case, Hummingbot will use ConstantMultipleSpreadPricingDelegate and StaggeredMultipleSizeSizingDelegate for the pricing and sizing plugins instead.
 
 ### ConstantSpreadPricingDelegate
 
-The logic of [`ConstantSpreadPricingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_spread_pricing_delegate.pyx) is simple. It will always propose a bid and an ask order at a pre-configured spread from the current mid-price.
+The logic of ConstantSpreadPricingDelegate is simple. It will always propose a bid and an ask order at a pre-configured spread from the current mid-price.
 
 ```cython
 object bid_price = mid_price * (Decimal(1) - self.bid_spread)
@@ -54,7 +54,7 @@ It doesn't do any checks about whether you have existing orders, or have enough 
 
 ### ConstantSizeSizingDelegate
 
-The logic inside [`ConstantSizeSizingDelegate`](https://github.com/CoinAlpha/hummingbot/blob/development/hummingbot/strategy/pure_market_making/constant_size_sizing_delegate.pyx) is more involved, because it's checking whether there're existing limit orders that are still active, and also whether there's enough balance in the exchange to create new orders.
+The logic inside ConstantSizeSizingDelegate is more involved, because it's checking whether there're existing limit orders that are still active, and also whether there's enough balance in the exchange to create new orders.
 
 In addition, this delegate is responsible for "quantizing" the orders, which means conforming them to the tick size and minimum order size required by this particular exchange's trading rules. Note that if a proposed order size is lower than minimum order size, the order size will be reduced to 0.
 

--- a/content/exchange-connectors/overview.mdx
+++ b/content/exchange-connectors/overview.mdx
@@ -3,49 +3,38 @@ title: Overview
 description:
 ---
 
-This section contains information about official connectors for individual exchanges and protocols, including:
-
-- General information
-- Setup and configuration
-- Minimum order sizes, fees, etc.
-
 ## What are Connectors?
 
 Connectors are packages of code that link Hummingbot's internal trading algorithms with live information from different cryptocurrency exchanges. They interact with a given exchange's API, such as by gathering order book data and sending and cancelling trades. See below for the list of exchanges which Hummingbot currently has connectors to.
 
-## Hummingbot-Supported Connectors
+Connector status
 
-- [Binance](/connectors/binance)
-- [Binance Futures](/connectors/binance-futures)
-- [Binance US](/connectors/binance-us)
-- [Bitfinex](/connectors/bitfinex)
-- [Bittrex Global](/connectors/bittrex)
-- [Coinbase Pro](/connectors/coinbase)
-- [Crypto.com](/connectors/crypto-com)
-- [Eterbase](/connectors/eterbase)
-- [Huobi Global](/connectors/huobi)
-- [Kraken](/connectors/kraken)
-- [KuCoin](/connectors/kucoin)
-- [Liquid](/connectors/liquid)
-- [Loopring](/connectors/loopring)
-- [Radar Relay](/connectors/radar-relay)
+[<span style="color:green; font-size:25px"> ⬤</span> ] Connector is working properly and safe to use
 
-## Community-Contributed Exchange Connectors
+[<span style="color:yellow; font-size:25px"> ⬤</span> ] Connector is either new or has one or more issues
 
-| Exchange     |             Github Contact              |              Support Contact               | Last Version Tested | Last Updated |                       Status                        | Known Issues |
-| ------------ | :-------------------------------------: | :----------------------------------------: | :-----------------: | :----------: | :-------------------------------------------------: | :----------: |
-| Bamboo Relay |   [Arctek](https://github.com/Arctek)   |  [Online Chat](https://bamboorelay.com/)   |       0.21.0        |    0.21.0    | <span style="color:green; font-size:25px">⬤</span>  |              |
-| Dolomite     | [zrubenst](https://github.com/zrubenst) | [Telegram](https://t.me/dolomite_official) |       0.20.0        |    0.21.0    | <span style="color:green; font-size:25px"> ⬤</span> |              |
+[<span style="color:red; font-size:25px"> ⬤</span> ] Connector is broken and unusable
 
-- Last Version Tested - Last reported Hummingbot version that the exchange connector maintainer has confirmed has been tested and is operational.
-- Last Updated - Last Hummingbot release which included an update to the exchange connector code.
+As of version 0.33.1
 
-### Exchange Connector Specific Support
+Exchange connectors
 
-Please contact the support contact listed in the above table for support questions that are specific for that exchange.
-
-### Reporting an Issue with a Community-Contributed Connector
-
-1. Create a Github issue and tag the Github contact to inform them of the issue.
-2. Report the issue to the exchange connector support contact.
-3. Send a message through Discord in [#community-connectors](https://discordapp.com/channels/530578568154054663/642099307922718730) channel.
+|                        Exchange                         |                        Status                        |
+| :-----------------------------------------------------: | :--------------------------------------------------: |
+|    [Bamboo Relay](/exchange-connectors/bamboo-relay)    |   <span style="color:red; font-size:25px">⬤</span>   |
+|         [Binance](/exchange-connectors/binance)         | <span style="color:green; font-size:25px"> ⬤</span>  |
+| [Binance Futures](/exchange-connectors/binance-futures) | <span style="color:green; font-size:25px"> ⬤</span>  |
+|      [Binance US](/exchange-connectors/binance-us)      | <span style="color:green; font-size:25px"> ⬤</span>  |
+|        [Bitfinex](/exchange-connectors/bitfinex)        | <span style="color:green; font-size:25px"> ⬤</span>  |
+|     [Bittrex Global](/exchange-connectors/bittrex)      | <span style="color:yellow; font-size:25px"> ⬤</span> |
+|      [Coinbase Pro](/exchange-connectors/coinbase)      | <span style="color:green; font-size:25px"> ⬤</span>  |
+|      [Crypto.com](/exchange-connectors/crypto-com)      | <span style="color:yellow; font-size:25px"> ⬤</span> |
+|        [Dolomite](/exchange-connectors/Dolomite)        |  <span style="color:red; font-size:25px"> ⬤</span>   |
+|        [Eterbase](/exchange-connectors/eterbase)        |  <span style="color:red; font-size:25px"> ⬤</span>   |
+|       [Huobi Global](/exchange-connectors/huobi)        | <span style="color:green; font-size:25px"> ⬤</span>  |
+|          [Kraken](/exchange-connectors/kraken)          | <span style="color:yellow; font-size:25px"> ⬤</span> |
+|          [KuCoin](/exchange-connectors/kucoin)          | <span style="color:green; font-size:25px"> ⬤</span>  |
+|          [Liquid](/exchange-connectors/liquid)          | <span style="color:green; font-size:25px"> ⬤</span>  |
+|        [Loopring](/exchange-connectors/loopring)        | <span style="color:green; font-size:25px"> ⬤</span>  |
+|            [OKEx](/exchange-connectors/okex)            |  <span style="color:red; font-size:25px"> ⬤</span>   |
+|     [Radar Relay](/exchange-connectors/radar-relay)     |  <span style="color:red; font-size:25px"> ⬤</span>   |

--- a/content/protocol-connectors/overview.mdx
+++ b/content/protocol-connectors/overview.mdx
@@ -3,8 +3,22 @@ title: Overview
 description:
 ---
 
-This section contains information about official connectors for individual exchanges and protocols, including:
+## What are Connectors?
 
-- General information
-- Setup and configuration
-- Minimum order sizes, fees, etc.
+Connectors are packages of code that link Hummingbot's internal trading algorithms with live information from different cryptocurrency exchanges. They interact with a given exchange's API, such as by gathering order book data and sending and cancelling trades. See below for the list of exchanges which Hummingbot currently has connectors to.
+
+Connector status
+
+[<span style="color:green; font-size:25px"> ⬤</span> ] Connector is working properly and safe to use
+
+[<span style="color:yellow; font-size:25px"> ⬤</span> ] Connector is either new or has one or more issues
+
+[<span style="color:red; font-size:25px"> ⬤</span> ] Connector is broken and unusable
+
+As of version 0.33.1
+
+Protocol Connectors
+
+|                    Exchange                    |                       Status                        |
+| :--------------------------------------------: | :-------------------------------------------------: |
+| [Balancer](/protocol-connectors/balancer) BETA | <span style="color:yellow; font-size:25px">⬤</span> |


### PR DESCRIPTION
Removed the broken links since they are no longer available
![image](https://user-images.githubusercontent.com/73882610/102026238-9f037900-3dd7-11eb-8196-cfc1f9b76849.png)



vs

![image](https://user-images.githubusercontent.com/73882610/102026249-aa56a480-3dd7-11eb-829a-195fb043dee0.png)
