### PR TITLE
docs/ fix broken links

### DIFF
--- a/content/developer/overview.mdx
+++ b/content/developer/overview.mdx
@@ -25,7 +25,7 @@ The following list some examples/templates that you can refer to when building t
 
 ## Exchange connector requirements
 
-1. A complete set of exchange connector files as listed [above](#exchange-connector-files).
+1. A complete set of exchange connector files as listed [above](https://docs.hummingbot.io/exchange-connectors/overview/).
 2. Unit tests (see [existing unit tests](https://github.com/CoinAlpha/hummingbot/tree/master/test/integration)):
 
    1. Exchange market test ([example](https://github.com/CoinAlpha/hummingbot/blob/master/test/integration/test_binance_market.py))
@@ -35,7 +35,7 @@ The following list some examples/templates that you can refer to when building t
 3. Documentation:
 
    - Code commenting (particularly for any code that is materially different from the templates/examples)
-   - Any specific instructions for the use of that exchange connector ([example](https://docs.hummingbot.io/connectors/binance/))
+   - Any specific instructions for the use of that exchange connector ([example](https://docs.hummingbot.io/exchange-connectors/binance/))
 
 ## Requirements for community-developed connectors
 

--- a/content/index.mdx
+++ b/content/index.mdx
@@ -27,7 +27,7 @@ This documentation site is organized into the following sections:
 
 - [Installation](/installation/overview): Learn how to install Hummingbot in various environments
 - [Operation](/operation/client): Learn how to use Hummingbot commands and other useful configuration
-- [Connectors](/connectors/overview): Learn about the various supported connectors info and configuration
+- [Connectors](/exchange-connectors/overview): Learn about the various supported connectors info and configuration
 - [Strategies](/strategies/overview): Learn how to use the various supported strategies and their parameters
 
 ## For advanced users and developers

--- a/content/operation/adv-command-ref.mdx
+++ b/content/operation/adv-command-ref.mdx
@@ -100,7 +100,7 @@ you can find ways of contacting the team or community in our [support section](/
 
 ### Why does Hummingbot need my Ethereum wallet private key?
 
-Strategies that transact on decentralized exchanges (such as [Radar Relay](/connectors/radar-relay), [Bamboo Relay](/connectors/bamboo-relay), and [Dolomite](/connectors/dolomite)) directly interact with smart contracts on the Ethereum blockchain. Therefore, transactions must be signed and authorized, which requires your private key.
+Strategies that transact on decentralized exchanges (such as [Radar Relay](/exchange-connectors/radar-relay), [Bamboo Relay](/exchange-connectors/bamboo-relay), and [Dolomite](/exchange-connectors/dolomite)) directly interact with smart contracts on the Ethereum blockchain. Therefore, transactions must be signed and authorized, which requires your private key.
 
 Run command `connect ethereum` to connect your Ethereum wallet with Hummingbot.
 

--- a/content/release-notes/0.14.0.mdx
+++ b/content/release-notes/0.14.0.mdx
@@ -6,7 +6,7 @@ title: "Version 0.14.0"
 
 ## 🔗 New Huobi Global connector
 
-Hummingbot now support [Huobi Global](https://www.hbg.com)! You can read more about how to use the Huobi Global connector in the [user manual](/connectors/huobi/).
+Hummingbot now support [Huobi Global](https://www.hbg.com)! You can read more about how to use the Huobi Global connector in the [user manual](/exchange-connectors/huobi/).
 
 ⚠️ Please note that there are some known issues for this connector which we are working on:
 

--- a/content/release-notes/0.17.0.mdx
+++ b/content/release-notes/0.17.0.mdx
@@ -8,7 +8,7 @@ title: "Version 0.17.0"
 
 Hummingbot now supports [Bittrex Global](https://global.bittrex.com/)! Bittrex is a global, centralized cryptocurrency exchange based in Seattle, USA. It is an intuitive and easy to navigate exchange platform often finding its way into the top 3 US exchanges in terms of trading volume.
 
-Read more about how to use Bittrex connector with Hummingbot in the [User Manual](https://docs.hummingbot.io/connectors/bittrex/).
+Read more about how to use Bittrex connector with Hummingbot in the [User Manual](https://docs.hummingbot.io/exchange-connectors/bittrex/).
 
 ## 📊 New performance analysis calculation
 

--- a/content/release-notes/0.18.0.mdx
+++ b/content/release-notes/0.18.0.mdx
@@ -10,7 +10,7 @@ The big news of the week was also the announcement of our upcoming new _liquidit
 
 Hummingbot can now trade on [Dolomite](https://dolomite.io/), using the connector contributed by the Dolomite team!
 
-The connector is now available in Hummingbot and should work with existing strategies. Read more about Dolomite connector in the [User Manual](/connectors/dolomite/).
+The connector is now available in Hummingbot and should work with existing strategies. Read more about Dolomite connector in the [User Manual](/exchange-connectors/dolomite/).
 
 ## 💾 Binary installation: you can now download Hummingbot directly!
 

--- a/content/release-notes/0.23.0.mdx
+++ b/content/release-notes/0.23.0.mdx
@@ -35,7 +35,7 @@ More information about [Basic Mode](https://docs.hummingbot.io/strategies/pure-m
 
 Hummingbot now supports [KuCoin](https://www.kucoin.com/) exchange! Nicknamed the "People's Exchange"​, Kucoin is easy to use for novice investors and in-depth enough for crypto enthusiasts. It has one of the world’s most impressive trading pair selections, a wide range of alt coins with more than 300 trading pairs and are adding new ones regularly.
 
-Read more about how to use KuCoin connector in the [User Manual](https://docs.hummingbot.io/connectors/kucoin/).
+Read more about how to use KuCoin connector in the [User Manual](https://docs.hummingbot.io/exchange-connectors/kucoin/).
 
 ## 📜 Error log collection
 

--- a/content/release-notes/0.26.0.mdx
+++ b/content/release-notes/0.26.0.mdx
@@ -42,7 +42,7 @@ Now you can use the revamped [config](/operation/command-ref/#config) command to
 
 Hummingbot now supports [Kraken](https://www.kraken.com/) exchange! Kraken is a centralized exchange where users can trade not only several cryptocurrencies but as well as various fiat currencies such as USD, CAD, EUR, GBP, CHF and JPY.
 
-Read more about how to use Kraken connector [here](https://docs.hummingbot.io/connectors/kraken/).
+Read more about how to use Kraken connector [here](https://docs.hummingbot.io/exchange-connectors/kraken/).
 
 ## 📱 Improved Telegram integration
 

--- a/content/release-notes/0.29.0.mdx
+++ b/content/release-notes/0.29.0.mdx
@@ -13,7 +13,7 @@ Currently, Scripts can only be used when running Hummingbot from source or with 
 
 ## 🔗 New connector: Eterbase
 
-Hummingbot now supports [Eterbase](https://www.eterbase.com/) exchange! Eterbase claims to be the first regulation-compliant European cryptocurrency exchange. Read more about how to use Eterbase connector [here](/connectors/eterbase/).
+Hummingbot now supports [Eterbase](https://www.eterbase.com/) exchange! Eterbase claims to be the first regulation-compliant European cryptocurrency exchange. Read more about how to use Eterbase connector [here](/exchange-connectors/eterbase/).
 
 ## 📊 New param: Take Crossed Orders
 

--- a/content/release-notes/0.32.0.mdx
+++ b/content/release-notes/0.32.0.mdx
@@ -8,7 +8,7 @@ Hummingbot now supports [Bitfinex](https://www.bitfinex.com/) exchange! Bitfinex
 
 Bitfinex was founded in December 2012 as a peer-to-peer Bitcoin exchange, offering digital asset trading services to users around the world. Bitfinex initially started as a P2P margin lending platform for Bitcoin and later added support for more cryptocurrencies.
 
-Read more about how to use Bitfinex connector [here](/connectors/bitfinex/).
+Read more about how to use Bitfinex connector [here](/exchange-connectors/bitfinex/).
 
 > **Note:** Bitfinex connector is currently not working with cross-exchange and arbitrage strategy.
 
@@ -16,7 +16,7 @@ Read more about how to use Bitfinex connector [here](/connectors/bitfinex/).
 
 The connector for [Loopring](https://loopring.io/) exchange is also in this release! Loopring is the first scalable DEX protocol built with zkRollup for Ethereum. Loopring Exchange is the first decentralized trading platform built on top of the Loopring protocol.
 
-Read more about how to use Loopring connector [here](/connectors/loopring/).
+Read more about how to use Loopring connector [here](/exchange-connectors/loopring/).
 
 ## 🎛 New pure market making feature: Order Override
 

--- a/content/strategies/cross-exchange-market-making.mdx
+++ b/content/strategies/cross-exchange-market-making.mdx
@@ -51,7 +51,7 @@ Initially, we assume that the maker exchange is an Ethereum-based decentralized 
 
 When placing orders on the maker market and filling orders on the taker market, the order amount should meet the exchange's minimum order size and minimum trade size.
 
-You can find more information about this for each [Connector](https://docs.hummingbot.io/connectors/overview/) under Miscellaneous section.
+You can find more information about this for each [Exchange Connectors](https://docs.hummingbot.io/exchange-connectors/overview/) under Miscellaneous section.
 
 ### Adjusting Orders and Maker Price calculations
 


### PR DESCRIPTION
fixed broken links when being redirected to the exchange connectors:

![image](https://user-images.githubusercontent.com/73882610/102036754-a1c59480-3dfe-11eb-8233-ccc355b40a3d.png)


![image](https://user-images.githubusercontent.com/73882610/102036763-a68a4880-3dfe-11eb-96ab-9eccbd22ff43.png)
