### PR TITLE
doc / remove dead links for .png 

### DIFF
--- a/content/operation/client.mdx
+++ b/content/operation/client.mdx
@@ -117,7 +117,7 @@ When running `create`, you are asked to select a strategy and enter strategy-spe
 - [Cross-exchange market making](/strategies/cross-exchange-market-making)
 - [Pure market making](/strategies/pure-market-making)
 
-> **Note:** When configuring your bot, make sure you are aware of your exchange's minimum order sizes and fees, and check that your trading pair has sufficient order book and trading volumes. You can find more info about specific exchanges in the [Connectors](/connectors/overview) section.
+> **Note:** When configuring your bot, make sure you are aware of your exchange's minimum order sizes and fees, and check that your trading pair has sufficient order book and trading volumes. You can find more info about specific exchanges in the [Connectors](/exchange-connectors/overview/) section.
 
 ## API keys
 

--- a/content/release-notes/0.10.0.mdx
+++ b/content/release-notes/0.10.0.mdx
@@ -20,8 +20,6 @@ Users can now also set either a positive or negative performance rate for `kill_
 
 ## 🌊 Backend logic for Liquidity Bounties
 
-![Internal leaderboard](/assets/img/liquidity-bounties.png)
-
 We have made substantial progress on the the data infrastructure required to collect, store, and verify trades performed by participants in our Liquidity Bounties. When we have completed the back-end work, we will build a leaderboard web application that bounty participants can use to see how much rewards they have accumulated and where they rank relative to others.
 
 All payouts will occur after the end of each monthly competition period.

--- a/content/release-notes/0.11.0.mdx
+++ b/content/release-notes/0.11.0.mdx
@@ -6,8 +6,6 @@ title: "Version 0.11.0"
 
 ## 📝 Introducing the Developer Manual
 
-![](/assets/img/developer-manual.png)
-
 We have created a new section in our docs for developers who want to contribute to Hummingbot and extend its capabilities.
 
 Initially, it's focused on helping users understand how Hummingbot strategies work, especially the pure market making strategy.
@@ -15,8 +13,6 @@ Initially, it's focused on helping users understand how Hummingbot strategies wo
 Over time, we will add more content to the other sections.
 
 ## 🤖 New strategy: `simple_trade`
-
-![](/assets/img/simple_trade.png)
 
 We added a new strategy: [Simple Trade](/developer/build-strategy/#simple-trade-strategy).
 

--- a/content/release-notes/0.2.0.mdx
+++ b/content/release-notes/0.2.0.mdx
@@ -8,8 +8,6 @@ title: "Version 0.2.0"
 
 You can now press Tab to auto-complete a command when you start typing it in the command line interface. In addition, dropdown menus display the available options as users select exchanges and trading pairs.
 
-![trading pair dropdown screenshot](/assets/img/trading-pair-dropdown.png)
-
 ## ☁ Support for Ethereum node services
 
 You don't have to run your own node anymore! `hummingbot` now supports cloud-based Ethereum node services such as Infura. For the full list of supported node services, please see this [link](/operation/adv-command-ref/#setup-ethereum-nodes).

--- a/content/release-notes/0.25.0.mdx
+++ b/content/release-notes/0.25.0.mdx
@@ -10,14 +10,12 @@ In order to address memory leaks that cause the bot to crash, we upgraded Python
 
 In addition, we advise users to not `stop` and `start` the bot frequently before running it long-term. This appears to elevate memory usage and cause the bot to crash more frequently. We continue to monitor this issue.
 
-!!! tip "Updating from source"
+> **Tip:** "Updating from source"
 Due to the updated Python version, users who install Hummingbot from source need to run `./uninstall` and `./clean` before updating.
 
 ## 💥 New `status` command
 
 We made some changes to how bot `status` is displayed to make it more informative for users.
-
-![](/assets/img/inventory-skew-2.png)
 
 - Added a new section if **Inventory Skew** is enabled
 - Added **Spread** to show the order's spread from the mid price

--- a/content/release-notes/0.5.0.mdx
+++ b/content/release-notes/0.5.0.mdx
@@ -16,8 +16,6 @@ We plan to add this to the [cross-exchange market making](/strategies/cross-exch
 
 We added and improved a number of the commands in the Hummingbot command line interface:
 
-![status command](/assets/img/status-command.png)
-
 - `status`: we revamped the output of the `status` command to be more consistent across strategies and to provide more granular information
 - `list configs`: this command now lists the value for each configuration parameter
 - `config [parameter name]`: this command, which allows users to change bot parameters without exiting Hummingbot, now supports tab auto-complete, which makes changing parameters much easier

--- a/content/release-notes/0.7.0.mdx
+++ b/content/release-notes/0.7.0.mdx
@@ -6,8 +6,6 @@ title: "Version 0.7.0"
 
 ## 🤖 New strategy: pure market making
 
-![pure market making](/assets/img/pure_mm.png)
-
 We have added the first version of a [pure market making strategy](/strategies/pure-market-making/), so all three strategies described in our [whitepaper](https://hummingbot.io/hummingbot.pdf) have now been released into production.
 
 Please note that this initial release contains a naive implementation that simply sets and maintains a constant spread around a trading pair's mid price. **Note that this is intended to be a basic template that users can test and customize. Running the strategy with substantial capital without additional modifications will likely lose money**.
@@ -15,8 +13,6 @@ Please note that this initial release contains a naive implementation that simpl
 Over the next few releases, we will add additional functionality that allows users of this strategy to incorporate important factors such as inventory level and market volatility.
 
 ## 🔗 New connector: Bamboo Relay
-
-![bamboo relay](/assets/img/bamboo_relay.png)
 
 Thanks to Hummingbot user `Joshua | Bamboo Relay`, we have our first community-contributed 3rd party exchange connector! [Bamboo Relay](https://bamboorelay.com/) is a 0x open order book relayer that offers active trading pairs in many ERC-20 Ethereum tokens, including DAI, MKR, and BAT.
 


### PR DESCRIPTION
Removed these line of codes from docs since the fille or image is missing

/release-notes/0.11.0/
/assets/img/developer-manual.png
/assets/img/simple_trade.png

/release-notes/0.25.0/
/assets/img/inventory-skew-2.png

/operation/client/
Fix link on connector on Note 

/release-notes/0.10.0/
/assets/img/liquidity-bounties.png

/release-notes/0.7.0/
/assets/img/pure_mm.png
/assets/img/bamboo_relay.png

/release-notes/0.5.0/
/assets/img/status-command.png

/release-notes/0.2.0/
/assets/img/trading-pair-dropdown.png
