### PR TITLE
doc / fix link on github in release 0.34

### DIFF
--- a/content/release-notes/0.34.0.mdx
+++ b/content/release-notes/0.34.0.mdx
@@ -33,8 +33,8 @@ Read more in our documentation how to use the connector [here](/protocol-connect
 In this release, we have made substantial improvements to the `amm-arb` strategy that can be used to arbitrage between AMM protocols and order book exchanges:
 
 - [#2672](https://github.com/CoinAlpha/hummingbot/issues/2672): Dynamically calculate gas price into Balancer
-- [#2734](https://github.com/CoinAlpha/hummingbot/issues/2672): Correctly add gas cost to Ethereum transactions
-- [#2694](https://github.com/CoinAlpha/hummingbot/issues/2672): Poll for Ethereum transactions from Hummingbot
+- [#2734](https://github.com/CoinAlpha/hummingbot/issues/2734): Correctly add gas cost to Ethereum transactions
+- [#2694](https://github.com/CoinAlpha/hummingbot/issues/2694): Poll for Ethereum transactions from Hummingbot
 
 We have also simplified the installation script for the Gateway module so that it automatically pulls certain values from the user's Hummingbot installation.
 


### PR DESCRIPTION
Changed the links on the github link on _improvements-to-AMM-Arbitrage-strategy_