### PR TITLE
docs / warning binary

### DIFF
--- a/content/release-notes/0.34.0.mdx
+++ b/content/release-notes/0.34.0.mdx
@@ -28,6 +28,8 @@ Terra is compatible with the [amm-arb](/strategies/amm-arb/) strategy, as well a
 
 Read more in our documentation how to use the connector [here](/protocol-connectors/terra).
 
+> **Warning:** Currently [dYdX](/exchange-connectors/dydx/), [terra](/protocol-connectors/terra) and [loopring](/exchange-connectors/loopring/) doesn't worked on Binary Installers.
+
 ## Improvements to AMM Arbitrage strategy
 
 In this release, we have made substantial improvements to the `amm-arb` strategy that can be used to arbitrage between AMM protocols and order book exchanges:

--- a/content/release-notes/0.34.0.mdx
+++ b/content/release-notes/0.34.0.mdx
@@ -28,7 +28,7 @@ Terra is compatible with the [amm-arb](/strategies/amm-arb/) strategy, as well a
 
 Read more in our documentation how to use the connector [here](/protocol-connectors/terra).
 
-> **Warning:** Currently [dYdX](/exchange-connectors/dydx/), [terra](/protocol-connectors/terra) and [loopring](/exchange-connectors/loopring/) doesn't worked on Binary Installers. It can only be used when running Hummingbot from source or with Docker.
+> **Warning:** Currently [dydx](/exchange-connectors/dydx/), [terra](/protocol-connectors/terra) and [loopring](/exchange-connectors/loopring/) don't work on Binary Installers. It can only be used when running Hummingbot from source or with Docker.
 
 ## Improvements to AMM Arbitrage strategy
 

--- a/content/release-notes/0.34.0.mdx
+++ b/content/release-notes/0.34.0.mdx
@@ -28,7 +28,7 @@ Terra is compatible with the [amm-arb](/strategies/amm-arb/) strategy, as well a
 
 Read more in our documentation how to use the connector [here](/protocol-connectors/terra).
 
-> **Warning:** Currently [dYdX](/exchange-connectors/dydx/), [terra](/protocol-connectors/terra) and [loopring](/exchange-connectors/loopring/) doesn't worked on Binary Installers.
+> **Warning:** Currently [dYdX](/exchange-connectors/dydx/), [terra](/protocol-connectors/terra) and [loopring](/exchange-connectors/loopring/) doesn't worked on Binary Installers. It can only be used when running Hummingbot from source or with Docker.
 
 ## Improvements to AMM Arbitrage strategy
 


### PR DESCRIPTION
- add warning when using binary installers for loopring, terra an dydx

![image](https://user-images.githubusercontent.com/54516858/103148717-ab0b1580-479d-11eb-8537-0abf740aad31.png)
