### PR TITLE
doc / add max order age to overview page

### DIFF
--- a/content/strategies/adv-market-making.mdx
+++ b/content/strategies/adv-market-making.mdx
@@ -12,16 +12,17 @@ There are two ways to configure these parameters:
 
 ## Advanced Pure Market Making Parameters
 
-| Parameter                                            | Definition                                                                                                                  |
-| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
-| [Order Levels](./order-levels)                       | Set the number of order levels to place for each side of the order book.                                                    |
-| [Inventory Skew](./inventory-skew)                   | Set and maintain a target inventory split between base and quote assets.                                                    |
-| [Filled Order Delay](./filled-order-delay)           | Set the duration of how long to wait before placing the next set of orders in case at least one of your orders gets filled. |
-| [Hanging Orders](./hanging-orders)                   | If enabled, the orders on the side opposite to the filled orders remains active.                                            |
-| [Minimum Spread](./minimum-spread)                   | Set the minimum spread value for active orders to be cancelled when the spread falls below this value                       |
-| [Order Refresh Tolerance](./order-refresh-tolerance) | Set the spread (from mid price) to defer order refresh process to the next cycle.                                           |
-| [Price Band](./price-band)                           | Place only sell orders when mid price goes above this price.                                                                |
-| [Ping Pong](./ping-pong)                             | Set the buy and sell orders to be place alternately.                                                                        |
-| [Order Optimization](./order-optimization)           | Set bid and ask order prices to be adjusted based on the current top bid and ask prices in the market.                      |
-| [Add Transaction Costs](./add-transaction-costs)     | If enabled, the transaction costs are added to order price calculation.                                                     |
-| [External Price Source](/strategies/external-price-source/)              | If enabled, set external pricing source for the mid price.                                                                  |
+| Parameter                                                   | Definition                                                                                                                  |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| [Order Levels](./order-levels)                              | Set the number of order levels to place for each side of the order book.                                                    |
+| [Inventory Skew](./inventory-skew)                          | Set and maintain a target inventory split between base and quote assets.                                                    |
+| [Filled Order Delay](./filled-order-delay)                  | Set the duration of how long to wait before placing the next set of orders in case at least one of your orders gets filled. |
+| [Hanging Orders](./hanging-orders)                          | If enabled, the orders on the side opposite to the filled orders remains active.                                            |
+| [Minimum Spread](./minimum-spread)                          | Set the minimum spread value for active orders to be cancelled when the spread falls below this value                       |
+| [Order Refresh Tolerance](./order-refresh-tolerance)        | Set the spread (from mid price) to defer order refresh process to the next cycle.                                           |
+| [Price Band](./price-band)                                  | Place only sell orders when mid price goes above this price.                                                                |
+| [Ping Pong](./ping-pong)                                    | Set the buy and sell orders to be place alternately.                                                                        |
+| [Order Optimization](./order-optimization)                  | Set bid and ask order prices to be adjusted based on the current top bid and ask prices in the market.                      |
+| [Add Transaction Costs](./add-transaction-costs)            | If enabled, the transaction costs are added to order price calculation.                                                     |
+| [External Price Source](/strategies/external-price-source/) | If enabled, set external pricing source for the mid price.                                                                  |
+| [Max Order Age](/strategies/max-order-age/)                 | Set the duration of the maximum age of the order, and it will be refreshed depending on the value set.                      |


### PR DESCRIPTION
Added max order age to the overview page of advanced market making

![image](https://user-images.githubusercontent.com/73882610/103810639-8f094d00-5096-11eb-972f-4c48d0a561bd.png)
