### PR TITLE
doc / installing miniconda typo

### DIFF
--- a/content/installation/linux.mdx
+++ b/content/installation/linux.mdx
@@ -266,7 +266,7 @@ sudo apt-get install -y build-essential git
 
 # 2) Install Miniconda3
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh
-sh Miniconda3-latest-Linux-x86_64.sh
+bash Miniconda3-latest-Linux-x86_64.sh
 
 # 3) Reload .bashrc to register "conda" command
 exec bash


### PR DESCRIPTION
Fixed typo on installing miniconda on linux

![image](https://user-images.githubusercontent.com/73882610/103901362-0214d100-5134-11eb-8646-d45dd450fdb4.png)
