### PR TITLE
doc / Fix broken link on release note 0.5.0

### DIFF
--- a/content/release-notes/0.5.0.mdx
+++ b/content/release-notes/0.5.0.mdx
@@ -28,7 +28,7 @@ We added and improved a number of the commands in the Hummingbot command line in
 New documentation in this release includes:
 
 - [Strategies](/strategies/overview/): diagrams and explanations of Hummingbot's strategies
-- [Debug console](/operation/debug/#gatsby-focus-wrapper): how to use the debug console to inspect your bot in real-time
+- [Debug console](/features/debug/): how to use the debug console to inspect your bot in real-time
 - Known issues: list of currently outstanding issues and their resolution status
 - [Windows installation](/installation/windows/): how to install Hummingbot on Windows
 - Exchange rates: how to use the exchange rates utility class to resolve price differences between stablecoins


### PR DESCRIPTION
Fixed broken link `Debug console`
- On version 0.5.0
![image](https://user-images.githubusercontent.com/71769411/104143341-040fb600-53fa-11eb-81aa-20988fe64421.png)
![image](https://user-images.githubusercontent.com/71769411/104143297-d460ae00-53f9-11eb-9cc8-889080db7c3d.png)