### PR TITLE
doc / fixed some info on release notes

### DIFF
--- a/content/release-notes/0.35.0.mdx
+++ b/content/release-notes/0.35.0.mdx
@@ -24,7 +24,6 @@ v0.34.0 added a feature that allows you to tell the bot how to manage open posit
 We've also made a number of smaller enhancements and bug fixes to this strategy in v0.35:
 
 - [#2786](https://github.com/CoinAlpha/hummingbot/pull/2786): Fixed an issue in which the the bot displayed an trading pair rule error when starting on testnet
-- [#2787](https://github.com/CoinAlpha/hummingbot/pull/2787): Removed extra take profit orders when using multiple order levels on perpetual market making.
 
 ## Usability improvements for protocol connectors
 

--- a/content/release-notes/0.35.0.mdx
+++ b/content/release-notes/0.35.0.mdx
@@ -19,11 +19,12 @@ Now, the strategy allows users to select how they want to manage any positions c
 
 ![](/img/position_mgmt.png)
 
-v0.35.0 adds a feature that allows you to tell the bot how to manage open positions. **Profit-taking** allows you to set spreads at which the bot will close positions to take profit, while **Trailing stop** allows you to set spreads at which the bot will close positions to prevent futher losses.
+v0.34.0 added a feature that allows you to tell the bot how to manage open positions. **Profit-taking** allows you to set spreads at which the bot will close positions to take profit, while **Trailing stop** allows you to set spreads at which the bot will close positions to prevent futher losses.
 
-We've also made a number of smaller enhancements and bug fixes to this strategy:
+We've also made a number of smaller enhancements and bug fixes to this strategy in v0.35:
 
 - [#2786](https://github.com/CoinAlpha/hummingbot/pull/2786): Fixed an issue in which the the bot displayed an trading pair rule error when starting on testnet
+- [#2787](https://github.com/CoinAlpha/hummingbot/pull/2787): Removed extra take profit orders when using multiple order levels on perpetual market making.
 
 ## Usability improvements for protocol connectors
 


### PR DESCRIPTION
Fixed some info on release notes regarding the take profit and trailing stop feature that was added in v0.34 not on 35 and added that we made small enhancements and bug fixes in v0.35

![image](https://user-images.githubusercontent.com/73882610/104266232-28d35e80-54ca-11eb-8a0e-9c7ff621a783.png)
