### PR TITLE
doc / Fixed broken links on release notes v0.35.0

### DIFF
--- a/content/release-notes/0.35.0.mdx
+++ b/content/release-notes/0.35.0.mdx
@@ -5,7 +5,7 @@ title: "Jan 2021 (v0.35.0)"
 _Released on January 11, 2021_
 
 - **Download installer**: [Windows](https://dist.hummingbot.io/hummingbot_v0.35.0_setup.exe) | [macOS](https://dist.hummingbot.io/hummingbot_v0.35.0.dmg)
-- **Install via Docker**: [Linux](installation/linux/#install-via-docker) | [Windows](/installation/windows/#install-via-docker) | [macOS](/installation/mac/#install-via-docker) | [Raspberry Pi](/installation/raspberry/)
+- **Install via Docker**: [Linux](/installation/linux/#install-via-docker) | [Windows](/installation/windows/#install-via-docker) | [macOS](/installation/mac/#install-via-docker) | [Raspberry Pi](/installation/raspberry/)
 
 ---
 
@@ -52,7 +52,7 @@ See [Balance Limit](https://docs.hummingbot.io/features/balance-limit/) page for
 
 ## Order optimization now works with multiple order levels
 
-In the [Pure Market Making](/strategies/pure_market_making) strategy, we have improved the `order_optimization` parameter to work with multiple order levels. Previously it would only work when `order_levels` equaled 1. See [Order Optimization](https://docs.hummingbot.io/strategies/order-optimization/) page for more information.
+In the [Pure Market Making](/strategies/pure-market-making) strategy, we have improved the `order_optimization` parameter to work with multiple order levels. Previously it would only work when `order_levels` equaled 1. See [Order Optimization](https://docs.hummingbot.io/strategies/order-optimization/) page for more information.
 
 ## Handle multiple fee tokens in `history`
 


### PR DESCRIPTION
Fixed two broken links on release notes v0.35.0
- Linux
- Pure market making
![image](https://user-images.githubusercontent.com/71769411/104398066-06ece100-5589-11eb-99b7-2336a837af30.png)
![image](https://user-images.githubusercontent.com/71769411/104398121-1cfaa180-5589-11eb-86ab-d282ad075b18.png)
