### PR TITLE
doc / changed info on overview page on installation

### DIFF
--- a/content/installation/overview.mdx
+++ b/content/installation/overview.mdx
@@ -5,15 +5,15 @@ description:
 
 Hummingbot has been successfully tested with the following specifications:
 
-| Resource             | Requirement                                                                                                                                                                                                |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Operating System** | **Linux**: Ubuntu 16.04 or later (recommended) \*Other Linux installations: Debian GNU/Linux 9, CentOS 7, Amazon Linux 2 AMI                                                                               |
-|                      | **MacOS**: macOS 10.12.6 (Sierra) or later                                                                                                                                                                 | 
-|                      | **Windows**: Windows 10 or later                                                                                                                                                                           |
-| **Memory/RAM**       | 1 GB one instance _+250 MB per additional instance_                                                                                                                                                        |
-| **Storage**          | **Install using Docker**: 5 GB per instance                                                                                                                                                                |
-|                      | **Install from source**: 3 GB per instance                                                                                                                                                                 |
-| **Network**          | A reliable internet connection is critical to keeping Hummingbot connected to exchanges.                                                                                                                   |
+| Resource             | Requirement                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| **Operating System** | **Linux**: Ubuntu 16.04 or later (recommended) \*Other Linux installations: Debian GNU/Linux 9, CentOS 7, Amazon Linux 2 AMI |
+|                      | **MacOS**: macOS 10.12.6 (Sierra) or later                                                                                   |
+|                      | **Windows**: Windows 10 or later                                                                                             |
+| **Memory/RAM**       | 1 GB one instance _+250 MB per additional instance_                                                                          |
+| **Storage**          | **Install using Docker**: 5 GB per instance                                                                                  |
+|                      | **Install from source**: 3 GB per instance                                                                                   |
+| **Network**          | A reliable internet connection is critical to keeping Hummingbot connected to exchanges.                                     |
 
 ## Supported-Installation Environments
 
@@ -35,7 +35,7 @@ As of **version 0.28.0** installing Docker takes up around 500 MB of storage spa
 | Provider              | Instance Type   | Instance Details      |
 | --------------------- | --------------- | --------------------- |
 | Google Cloud Platform | g1-small        | 1 vCPU, 1.7 GB memory |
-| Amazon Web Services   | t2.micro        | 1 vCPU, 1 GB memory   |
+| Amazon Web Services   | t2.small        | 1 vCPU, 1 GB memory   |
 | Microsoft Azure       | Standard_D2s_v3 | 2 vCPU, 8 GB memory   |
 
 These instances are pre-loaded with system files that takes up around 1.2 GB so we recommend having at least **8 GB of storage space** in your cloud server.


### PR DESCRIPTION
Changed t2.micro to t2.small on cloud server needed to run Hummingbot

![image](https://user-images.githubusercontent.com/73882610/104487708-65a56f80-5608-11eb-94da-0720422ae163.png)
