### PR TITLE
balance paper clarification regarding exchange inventory

### DIFF
--- a/content/features/paper-trade.mdx
+++ b/content/features/paper-trade.mdx
@@ -60,3 +60,5 @@ Paper account balances:
      WETH    10.0000
       ZRX  1000.0000
 ```
+
+A restart might be required in order to make any `balance paper` change to reflect the paper trade exchange inventory for `status` command.


### PR DESCRIPTION
After fixing paper balances, the paper trade mode still does not automatically start or kick in, but a further restart is needed in order to populate fake exchange balances. Resolved this with the support team in the Discord chat.