### PR TITLE
doc / fix notes and warnings on docs

### DIFF
--- a/content/release-notes/0.25.0.mdx
+++ b/content/release-notes/0.25.0.mdx
@@ -10,7 +10,7 @@ In order to address memory leaks that cause the bot to crash, we upgraded Python
 
 In addition, we advise users to not `stop` and `start` the bot frequently before running it long-term. This appears to elevate memory usage and cause the bot to crash more frequently. We continue to monitor this issue.
 
-!!! tip "Updating from source"
+> **Note**:  "Updating from source"
 Due to the updated Python version, users who install Hummingbot from source need to run `./uninstall` and `./clean` before updating.
 
 ## 💥 New `status` command

--- a/content/release-notes/0.26.0.mdx
+++ b/content/release-notes/0.26.0.mdx
@@ -4,7 +4,7 @@ title: "Version 0.26.0"
 
 🚀 Welcome to `hummingbot` version 0.26.0! This release contains a lot of changes in the Hummingbot client, aimed at improving the user experience for new and existing users alike.
 
-!!! note "Old config files won't work"
+> **Note:** "Old config files won't work"
 This release contains many changes to the import process, so previous strategy configuration files will not be compatible with this version.
 
 ## 🔐 New password screen

--- a/content/release-notes/0.28.0.mdx
+++ b/content/release-notes/0.28.0.mdx
@@ -4,7 +4,7 @@ title: "Version 0.28.0"
 
 🚀 Welcome to `hummingbot` version 0.28.0! This release contains the new Celo connector and the new `celo-arb` strategy, new parameters like Ping Pong and Minimum Spread, along with a number of bug fixes and enhancements.
 
-!!! tip "Help shape the direction of the Hummingbot codebase"
+> **Note:** "Help shape the direction of the Hummingbot codebase"
 In order to communicate the status of bug fixes and planned improvements, we recently began to publish the [Hummingbot Public Roadmap](https://github.com/CoinAlpha/hummingbot/projects/2). Help us prioritize stories by commenting on the ones you want, and feel free to submit new stories.
 
 ## 🌞 New Celo connector and strategy

--- a/content/release-notes/0.29.0.mdx
+++ b/content/release-notes/0.29.0.mdx
@@ -8,7 +8,7 @@ title: "Version 0.29.0"
 
 The new Scripts feature allows the user to create mini-Python functions that adjust how Hummingbot behaves. For example, users can automate changes to bot params when certain conditions are met. Read more about the scripts feature in the [Scripts](/scripts/script-base/#scriptbase) section in the documentation.
 
-!!! warning
+> **Warning:**
 Currently, Scripts can only be used when running Hummingbot from source or with Docker. Using this feature in the Mac or Windows installers will crash the bot.
 
 ## 🔗 New connector: Eterbase

--- a/content/release-notes/0.34.0.mdx
+++ b/content/release-notes/0.34.0.mdx
@@ -73,7 +73,6 @@ For these reasons, in this release, a “heartbeat” data collection mechanism 
 If you have any question, please don't hesitate to reach out to anyone from the core team via Discord or email. Thank you again for your support.
 
 > **NOTE:**
-
 - The data will be neither accessible nor sold to any third party
 - Your personally identifiable data will not be collected
 


### PR DESCRIPTION
Fix typos on notes and warnings on docs on the following link,
https://docs.hummingbot.io/release-notes/0.25.0/
https://docs.hummingbot.io/release-notes/0.26.0/
https://docs.hummingbot.io/release-notes/0.28.0/
https://docs.hummingbot.io/release-notes/0.29.0/
https://docs.hummingbot.io/release-notes/0.34.0/