### PR TITLE
doc / removed extra headers and fix typos

### DIFF
--- a/content/developer/task3.mdx
+++ b/content/developer/task3.mdx
@@ -4,8 +4,6 @@ title: "Task 3 — Market Connector"
 description: Info on market connector
 ---
 
-## Task 3. Market Connector
-
 The primary bulk of integrating a new exchange connector is in this section.
 
 The role of the `Market` class can be broken down into placing and tracking orders. Although this might seem pretty straightforward, it does require a certain level of understanding and knowing the expected side-effect(s) of certain functions.

--- a/content/developer/tutorial.mdx
+++ b/content/developer/tutorial.mdx
@@ -5,7 +5,7 @@ description: Info on developing connector
 
 ## Building Connectors
 
-> **Note** " This [page](https://www.notion.so/hummingbot/a26c8bcf30284535b0e5689d45a4fe88?v=869e73f78f0b426288476a2abda20f2c) lists all relevant updates to Hummingbot codebase aimed to help connector developers in making the requisite changes to their connectors.
+> **Note:** This [page](https://www.notion.so/hummingbot/a26c8bcf30284535b0e5689d45a4fe88?v=869e73f78f0b426288476a2abda20f2c) lists all relevant updates to Hummingbot codebase aimed to help connector developers in making the requisite changes to their connectors.
 
 Each exchange connector is comprised of the following components:
 

--- a/content/exchange-connectors/binance-futures.mdx
+++ b/content/exchange-connectors/binance-futures.mdx
@@ -1,6 +1,6 @@
 ---
 title: Binance Futures (BETA)
-description: About Binance Futures Connecter (USDT-M)
+description: About Binance Futures Connector (USDT-M)
 ---
 
 <table>

--- a/content/exchange-connectors/binance-us.mdx
+++ b/content/exchange-connectors/binance-us.mdx
@@ -1,6 +1,6 @@
 ---
 title: Binance US
-description: About Binance US Connecter
+description: About Binance US Connector
 ---
 
 Launched in September 2019, Binance.US is a digital asset marketplace, powered by matching engine and wallet technologies licensed from the world’s largest cryptocurrency exchange, Binance. Operated by BAM Trading Services based in San Francisco, California, Binance.US provides a fast, secure and reliable platform to buy and sell cryptocurrencies in the United States.

--- a/content/exchange-connectors/binance.mdx
+++ b/content/exchange-connectors/binance.mdx
@@ -1,6 +1,6 @@
 ---
 title: Binance
-description: About Binance Connecter
+description: About Binance Connector
 ---
 
 Binance is a global cryptocurrency exchange that provides a platform for trading more than 100 cryptocurrencies. It is considered one of the top cryptocurrency trading platforms by volume. It also serves as a wallet for users who hold accounts on the exchange.

--- a/content/exchange-connectors/bittrex.mdx
+++ b/content/exchange-connectors/bittrex.mdx
@@ -1,6 +1,6 @@
 ---
 title: Bittrex Global
-description: About Bittrex Global Connecter
+description: About Bittrex Global Connector
 ---
 
 Bittrex is a global, centralized cryptocurrency exchange based in Seattle, USA. It was founded in 2013 and began its operations in 2014. It is an intuitive and easy to navigate exchange platform often finding its way into the top 3 US exchanges in terms of trading volume.

--- a/content/exchange-connectors/dydx.mdx
+++ b/content/exchange-connectors/dydx.mdx
@@ -3,8 +3,6 @@ title: dYdX
 description: About dYdX Exchange Connector
 ---
 
-## About dYdX
-
 dYdX describes itself as a full-featured decentralized exchange (originating from the US) for spot and margin trading. dYdX is built on Ethereum, and launched at the beginning of May 2019 with spot and margin trading on ETH-DAI. dYdX claims to offer one of the most liquid order books across decentralized exchanges.
 
 ## Using the Connector

--- a/content/exchange-connectors/loopring.mdx
+++ b/content/exchange-connectors/loopring.mdx
@@ -3,8 +3,6 @@ title: Loopring
 description: About Loopring Exchange Connector
 ---
 
-## About Loopring
-
 Loopring is the first scalable DEX protocol built with zkRollup for Ethereum. Loopring Exchange is the first decentralized trading platform built on top of the Loopring protocol. Loopring Exchange is accessible at Loopring.io
 
 ## Using the Connector

--- a/content/exchange-connectors/okex.mdx
+++ b/content/exchange-connectors/okex.mdx
@@ -1,6 +1,6 @@
 ---
 title: OKEx
-description: About OKEx Connecter
+description: About OKEx Connector
 ---
 
 OKEx is a world-leading cryptocurrency exchange, providing advanced financial services to traders globally by using blockchain technology.


### PR DESCRIPTION
Remove headers from 
- About header on Loopring
- About header on dydx
- Task3 header on Task3

Fix Typo on
- "Connector" on connectors/binance-futures
- "Connector" on connectors/binance-us
- "Connector" on connectors/binance
- "Connector" on connectors/bittrex
- Fix notes on developer/ tutorial
