### PR TITLE
doc / add warning on certain connectors not working on binary

### DIFF
--- a/content/exchange-connectors/dydx.mdx
+++ b/content/exchange-connectors/dydx.mdx
@@ -3,6 +3,8 @@ title: dYdX
 description: About dYdX Exchange Connector
 ---
 
+import Callout from "../../src/components/Callout";
+
 dYdX describes itself as a full-featured decentralized exchange (originating from the US) for spot and margin trading. dYdX is built on Ethereum, and launched at the beginning of May 2019 with spot and margin trading on ETH-DAI. dYdX claims to offer one of the most liquid order books across decentralized exchanges.
 
 ## Using the Connector
@@ -26,6 +28,8 @@ Also note that your wallet must have funds deposited to dYdX to avoid getting th
 ```
 Error: DydxAPIError(status_code=400)(response={'errors': [{'name': 'AccountNotFoundError'}]})
 ```
+
+<Callout type="warning" body="Currently [dydx], [terra], and [loopring] don't work on Binary Installers. It can only be used when running Hummingbot from source or with Docker." link={["/exchange-connectors/dydx/","/protocol-connectors/terra","/exchange-connectors/loopring/"]}/>
 
 ## Miscellaneous Info
 

--- a/content/exchange-connectors/loopring.mdx
+++ b/content/exchange-connectors/loopring.mdx
@@ -3,6 +3,8 @@ title: Loopring
 description: About Loopring Exchange Connector
 ---
 
+import Callout from "../../src/components/Callout";
+
 Loopring is the first scalable DEX protocol built with zkRollup for Ethereum. Loopring Exchange is the first decentralized trading platform built on top of the Loopring protocol. Loopring Exchange is accessible at Loopring.io
 
 ## Using the Connector
@@ -11,7 +13,7 @@ To use the Loopring Exchange connector to trade using Hummingbot, you will need 
 
 ```
 Enter your Loopring account id >>>
-Enter the Loopring exchange id >>>
+Enter the Loopring exchange address >>>
 Enter your Loopring private key >>>
 Enter your loopring api key >>>
 ```
@@ -34,13 +36,15 @@ Private keys and API keys are stored locally for the operation of the Hummingbot
 
 ![](/img/loopring-api.png)
 
-You will be presented with your account information, which will include entries for "accountId", "exchangeId", "privateKey", and "apiKey". These values associated with these keys correspond to the required information you will need to connect the Loopring connector.
+You will be presented with your account information, which will include entries for "accountId", "exchangeAddress", "privateKey", and "apiKey". These values associated with these keys correspond to the required information you will need to connect the Loopring connector.
 
 Make sure to keep this information private and to not share it with anyone. You can re-view this information at anytime by clicking on **Export Account** again.
 
-> **Warning:** Please keep your EdDSA key pair and ApiKey strictly confidential. If you leak this information, your assets will be at risk. Loopring Exchange's UI and its API will never ask you for your EdDSA private key.
+<Callout type="warning" body="Please keep your EdDSA key pair and ApiKey strictly confidential. If you leak this information, your assets will be at risk. Loopring Exchange's UI and its API will never ask you for your EdDSA private key."/>
 
 More information about Loopring Key Management can be found on [this page](https://docs.loopring.io/en/basics/key_mgmt.html).
+
+<Callout type="warning" body="Currently [dydx], [terra], and [loopring] don't work on Binary Installers. It can only be used when running Hummingbot from source or with Docker." link={["/exchange-connectors/dydx/","/protocol-connectors/terra","/exchange-connectors/loopring/"]}/>
 
 ## Miscellaneous Info
 

--- a/content/protocol-connectors/terra.mdx
+++ b/content/protocol-connectors/terra.mdx
@@ -2,6 +2,8 @@
 title: Terra (BETA)
 ---
 
+import Callout from "../../src/components/Callout";
+
 The [Terra Protocol](https://terra.money/) is the creator of the Luna Token, Terra Core, and the blockchain payment solution CHAI. The design of the Terra Protocol is based on two things: stability and adoption by e-commerce platforms.
 
 It runs on a Tendermint Delegated Proof of Stake algorithm and Cosmos SDK. It is aimed at becoming a new worldwide financial infrastructure on which different DApps can be created.
@@ -34,3 +36,5 @@ Source: https://medium.com/stakin/what-is-terra-money-8eb1dcb314d2
 4. Create and run an `amm_arb` strategy to use the Terra connector
 
 ![](img/connect-terra.gif)
+
+<Callout type="warning" body="Currently [dydx], [terra], and [loopring] don't work on Binary Installers. It can only be used when running Hummingbot from source or with Docker." link={["/exchange-connectors/dydx/","/protocol-connectors/terra","/exchange-connectors/loopring/"]}/>


### PR DESCRIPTION
Add warning on certain connectors not working on binary build. Also updated info on Loopring to reflect needed information when connecting to the bot in preparation for Loopring v2 upgrade.
<img width="952" alt="Screen Shot 2021-02-04 at 7 47 26 PM" src="https://user-images.githubusercontent.com/64377055/106889804-79358900-6723-11eb-91d9-179df70335bd.png">
<img width="952" alt="Screen Shot 2021-02-04 at 7 47 46 PM" src="https://user-images.githubusercontent.com/64377055/106889893-99654800-6723-11eb-9c34-07924eff0b97.png">
<img width="1004" alt="Screen Shot 2021-02-04 at 7 37 18 PM" src="https://user-images.githubusercontent.com/64377055/106889913-9ec29280-6723-11eb-9dbe-68b35d84a17a.png">
<img width="758" alt="Screen Shot 2021-02-04 at 7 44 41 PM" src="https://user-images.githubusercontent.com/64377055/106889923-a41fdd00-6723-11eb-880f-682f85c34c25.png">
<img width="731" alt="Screen Shot 2021-02-04 at 7 44 32 PM" src="https://user-images.githubusercontent.com/64377055/106889939-a8e49100-6723-11eb-9b91-513539ffd739.png">
