### PR TITLE
refactor / raspberry pi link

### DIFF
--- a/content/release-notes/0.36.0.mdx
+++ b/content/release-notes/0.36.0.mdx
@@ -7,7 +7,7 @@ import Callout from "../../src/components/Callout";
 _Released on February 08, 2021_
 
 - **Download Installer**: [Windows](https://dist.hummingbot.io/hummingbot_v0.36.0_setup.exe) | [macOS](https://dist.hummingbot.io/hummingbot_v0.36.0.dmg)
-- **Install via Docker**: [Linux](/installation/linux/#install-via-docker) | [Windows](/installation/windows/#install-via-docker) | [macOS](/installation/mac/#install-via-docker)| [Raspberry Pi](/installation/raspberry/#install-via-docker-beta)
+- **Install via Docker**: [Linux](/installation/linux/#install-via-docker) | [Windows](/installation/windows/#install-via-docker) | [macOS](/installation/mac/#install-via-docker)| [Raspberry Pi](/installation/raspberry/)
 
 ---
 


### PR DESCRIPTION
fix the raspberry pi link on release notes

![image](https://user-images.githubusercontent.com/73882610/107503956-95c73a80-6bd5-11eb-9e4e-69d558010579.png)
