### PR TITLE
doc / remove extra symbols

### DIFF
--- a/content/strategies/perpetual-market-making.mdx
+++ b/content/strategies/perpetual-market-making.mdx
@@ -48,8 +48,6 @@ Enter the leverage you would like to use.
 
 Generally, the Perpetual market making strategy can manage two different types of position modes :
 
-{" "}
-
 <Callout
   type="note"
   body="Some perpetual connectors may offer either of the modes or both."
@@ -178,7 +176,6 @@ The bot will create orders depending on the `long_profit_taking_spread` and `sho
 ### `Trailing_stop`
 
 Trailing would begin if the current price is beyond or equal to the set `ts_activation_spread`. Setting this parameter to zero would start the trailing immediately the position is opened.
-/>
 
 `ts_activation_spread`
 


### PR DESCRIPTION
Remove extra symbols from the Perpetual market making strategy docs

Before:
<img width="755" alt="Screen Shot 2021-02-11 at 6 56 34 PM" src="https://user-images.githubusercontent.com/64377055/107628477-9fb37100-6c9b-11eb-9f34-e63efc8c6802.png">
<img width="736" alt="Screen Shot 2021-02-11 at 6 57 11 PM" src="https://user-images.githubusercontent.com/64377055/107628492-a510bb80-6c9b-11eb-94f3-72129e8cc8e7.png">

After:
<img width="757" alt="Screen Shot 2021-02-11 at 6 56 46 PM" src="https://user-images.githubusercontent.com/64377055/107628498-a9d56f80-6c9b-11eb-8033-6a94d604b47f.png">
<img width="736" alt="Screen Shot 2021-02-11 at 6 57 18 PM" src="https://user-images.githubusercontent.com/64377055/107628506-ad68f680-6c9b-11eb-8b10-30c3e256a46b.png">


