### PR TITLE
fix / release notes and broken links for pure market making 

### DIFF
--- a/content/release-notes/0.22.0.mdx
+++ b/content/release-notes/0.22.0.mdx
@@ -18,10 +18,10 @@ The Radar Relay connector is broken right now because they recently moved their 
 
 Here we list recent major changes to Hummingbot docs:
 
-- Added [Liquidity Mining FAQ](https://docs.hummingbot.io/miner/faq/liquidity-mining/) and list of upcoming campaigns
+- Added [Hummingbot Help Center](https://hummingbot.zendesk.com/hc/en-us/categories/900000269026-Liquidity-Mining-FAQs)
 - Added External Pricing Source Configuration in Pure Market Making strategy
 - Added steps in Troubleshooting section on how to locate the data folder where hummingbot_trades.sqlite folder is stored when running via Docker
-- Added information in Troubleshooting section about Binance 
+- Added information in Troubleshooting section about Binance
 - Removed Bitcoin.com Exchange since this is no longer supported
 
 ## 🐞 Other bug fixes

--- a/content/release-notes/0.23.0.mdx
+++ b/content/release-notes/0.23.0.mdx
@@ -20,7 +20,7 @@ Please refer to the following links and resources for more information:
 
 - [Hummingbot Miners](https://miners.hummingbot.io)
 - [Participation Guide](https://docs.hummingbot.io/miner/liquidity-mining/overview/)
-- [Liquidity Mining FAQs](https://docs.hummingbot.io/miner/faq/liquidity-mining/)
+- [Hummingbot Help Center](https://hummingbot.zendesk.com/hc/en-us/categories/900000269026-Liquidity-Mining-FAQs)
 - [Liquidity Mining Policy](https://hummingbot.io/liquidity-mining-policy/)
 
 ## 📊 Pure market making configuration simplified

--- a/content/release-notes/0.36.0.mdx
+++ b/content/release-notes/0.36.0.mdx
@@ -15,7 +15,7 @@ _Released on February 08, 2021_
 
 In this release, Hummingbot has added two more exchanges in its vast spectrum of connectors. Hummingbot now supports [BitMax](https://bitmax.io/en/global-digital-asset-platform) exchange! BitMax describes itself as a global digital asset trading platform; exchange for Bitcoin and other crypto coins & tokens; innovator of staking, margin & derivative trading products. BitMax is a Singapore based crypto exchange launched in July 2018. The bitmax.io domain name was created on February 23, 2018. The exchange offers crypto-to-crypto trading of 36 coins in 72 pairs with three markets (BTC, USDT, and ETH).
 
-Bitmax is compatible with [pure market making](strategies/pure-market-making/), [cross-exchange market-making](/strategies/cross-exchange-market-making/), and [arbitrage strategies](/strategies/arbitrage/).
+Bitmax is compatible with [pure market making](https://docs.hummingbot.io/strategies/pure-market-making/), [cross-exchange market-making](/strategies/cross-exchange-market-making/), and [arbitrage strategies](/strategies/arbitrage/).
 
 Read more about how to use the BitMax connector [here](/exchange-connectors/bitmax).
 
@@ -23,7 +23,7 @@ Read more about how to use the BitMax connector [here](/exchange-connectors/bitm
 
 We are glad to present to you that Hummingbot now supports [Blocktane](https://blocktane.io/) exchange! Blocktane is an exchange created by veterans of global financial markets with trading and operations experience at the largest financial exchanges. Blocktane delivers to the Brazilian market the smartest way to buy and sell digital assets.
 
-Blocktane is compatible with [pure market making](strategies/pure-market-making/), [cross-exchange market-making](/strategies/cross-exchange-market-making/), and [arbitrage strategies](/strategies/arbitrage/).
+Blocktane is compatible with [pure market making](https://docs.hummingbot.io/strategies/pure-market-making/), [cross-exchange market-making](/strategies/cross-exchange-market-making/), and [arbitrage strategies](/strategies/arbitrage/).
 
 Read more about how to use the Blocktane connector [here](/exchange-connectors/blocktane).
 


### PR DESCRIPTION
Fixed broken links for pure market making and changed "Liquidity Mining FAQs" to "Hummingbot Help Center" 

![image](https://user-images.githubusercontent.com/78310937/107775482-4ae72780-6d7b-11eb-9160-202aaf185280.png)

![image](https://user-images.githubusercontent.com/78310937/107775524-5c303400-6d7b-11eb-974b-6e6628e67621.png)

![image](https://user-images.githubusercontent.com/78310937/107775601-7b2ec600-6d7b-11eb-8d7f-472b260e5e11.png)

