### PR TITLE
doc / add hyperlink of pingpong in pure market making

### DIFF
--- a/content/strategies/pure-market-making.mdx
+++ b/content/strategies/pure-market-making.mdx
@@ -123,7 +123,7 @@ The order amount for the limit bid and ask orders. Ensure you have enough quote 
 
 ### `ping_pong_enabled`
 
-Whether to alternate between buys and sells.
+Whether to alternate between buys and sells. For more information on this parameter click this [link](https://docs.hummingbot.io/strategies/ping-pong/).
 
 ** Prompt: **
 


### PR DESCRIPTION
* Add hyperlink of `ping_pong` in pure market making

![jI61pYznxY](https://user-images.githubusercontent.com/73885708/107971132-0662c280-6fed-11eb-957f-d80b763f8773.gif)
