### PR TITLE
doc / adjust bitmax flat fee trade

### DIFF
--- a/content/exchange-connectors/bitmax.mdx
+++ b/content/exchange-connectors/bitmax.mdx
@@ -68,7 +68,7 @@ See [this page](https://bitmaxhelp.zendesk.com/hc/en-us/articles/360025991074-Up
 
 ### Transaction Fees
 
-By default, trading fees for this exchange charges a flat fee of 0.04% per trade.
+By default, trading fees for this exchange charges a fee of 0.025% for makers and 0.050% for takers per trade.
 
 - [Fees](https://bitmaxhelp.zendesk.com/hc/en-us/articles/360043045614-Fees)
 


### PR DESCRIPTION
adjust bitmax flat fee trade from .04% to 0.025% for makers and 0.050% for takers per trade.

![image](https://user-images.githubusercontent.com/78801399/108162379-f56a9c00-7127-11eb-89b6-701be87d60c3.png)
