### PR TITLE
doc / updated notes on strategies overview

### DIFF
--- a/content/strategies/liquidity-mining.mdx
+++ b/content/strategies/liquidity-mining.mdx
@@ -8,7 +8,7 @@ import Prompt from "../../src/components/Prompt";
 import Callout from "../../src/components/Callout";
 
 <Callout
-  type="note"
+  type="warning"
   body="This experimental strategy has undergone code review, internal testing and was shipped during one of our most recent releases. As part of User Acceptance Testing, we encourage user to report any issues and/or provide feedback with this strategy in our [Discord server] or [submit a bug report]"
   link={["https://discord.com/invite/2MN3UWg", "https://github.com/CoinAlpha/hummingbot/issues/new?assignees=&labels=bug&template=bug_report.md&title="]}
 />

--- a/content/strategies/overview.mdx
+++ b/content/strategies/overview.mdx
@@ -3,13 +3,19 @@ title: Overview
 description: Learn how to use the different strategies
 ---
 
+import Callout from "../../src/components/Callout";
+
 The current release of Hummingbot comes with six strategies:
 
 ### Pure Market Making
 
 Post buy and sell offers for an instrument on a single exchange, automatically adjust prices while actively managing inventory.
 
-For experienced users of this strategy, see [Advanced Market Making](adv-market-making) for how to use more sophisticated features of this strategy.
+<Callout
+    type="tip"
+    body="For experienced users of this strategy, see [Advanced Market Making] for how to use more sophisticated features of this strategy."
+    link={["adv-market-making"]}
+/>
 
 ### Cross Exchange Market Making
 
@@ -31,6 +37,16 @@ The celo-arb strategy is a special case of the normal arbitrage strategy that ar
 
 For more information, please see this [blog post](https://hummingbot.io/blog/2020-06-celo-arbitrage/).
 
-### Balance Arbitrage
+### AMM Arbitrage 
 
-Similar to celo-arb strategy that arbitrages between the automated market maker (AMM) exchange on the Balancer blockchain and other markets supported by Hummingbot.
+AMM-arb lets you exploit the differences between AMMs like [Balancer](/protocol-connectors/balancer/) and order book exchanges like Binance. Extending the celo-arb strategy released a few months ago, amm-arb uses a new, simpler design that works with any AMM protocol, on both Ethereum and non-Ethereum chain. You can take a look on our supported [Protocol Connectors](/protocol-connectors/overview/) for this strategy
+
+### Liquidity Mining Strategy (BETA)
+
+Released on [version 0.36.0](/release-notes/0.36.0/)
+Liquidity mining strategy is still in **BETA**. This is designed so users can run a single strategy and earn rewards on multiple markets but different pairs without the same base or qoute are not available at the same time. Reduced the number of parameters needed and has dynamic spread adjustment on market volatility. 
+
+<Callout
+    type="tip"
+    body="Liquidity mining strategy will have more features on future releases"
+/>


### PR DESCRIPTION
- Updated notes on strategies overview
- Changed callout for LM 

Apologies the 'commit' looks like I noted 'exchange connectors' instead of 'strategies overview'