### PR TITLE
doc / article link for integrating connectors

### DIFF
--- a/content/exchange-connectors/overview.mdx
+++ b/content/exchange-connectors/overview.mdx
@@ -9,6 +9,8 @@ import StatusCircle from "../../src/components/StatusCircle";
 
 Connectors are packages of code that link Hummingbot's internal trading algorithms with live information from different cryptocurrency exchanges. They interact with a given exchange's API, such as by gathering order book data and sending and cancelling trades.
 
+Related article : [How connectors are integrated into Hummingbot](https://hummingbot.zendesk.com/hc/en-us/articles/900004506986)
+
 ## Exchange Connector Status
 
 Below are the status of each connector as of version 0.36.

--- a/content/protocol-connectors/overview.mdx
+++ b/content/protocol-connectors/overview.mdx
@@ -6,6 +6,8 @@ title: Overview
 
 Connectors are packages of code that link Hummingbot's internal trading algorithms with live information from different cryptocurrency exchanges. They interact with a given exchange's API, such as by gathering order book data and sending and cancelling trades.
 
+Related article : [How connectors are integrated into Hummingbot](https://hummingbot.zendesk.com/hc/en-us/articles/900004506986)
+
 ## Protocol Connector Status
 
 Below are the status of each connector as of version 0.36.


### PR DESCRIPTION
- Added a link in exchange / protocol connectors overview that directs to the Help Center article on how connectors are integrated into Hummingbot

![image](https://user-images.githubusercontent.com/50150287/108314558-0cc38b00-71f5-11eb-8bcd-4a1bd1a54321.png)
