### PR TITLE
doc / additional notes for macOS  installation

### DIFF
--- a/content/installation/mac.mdx
+++ b/content/installation/mac.mdx
@@ -39,6 +39,12 @@ The application data files (e.g. logs and config files) are located differently 
 
 For the macOS .dmg distribution, the application data files are located in `~/Library/Application\ Support/Hummingbot`
 
+
+<Callout 
+  type="tip"
+  body="For error #'cannot be opened because the developer cannot be verified'#, you can `click then open` to run the installer"
+/>
+
 ## Install via Docker
 
 1. Install Docker


### PR DESCRIPTION
Added tip callout for macOS binary installation 

![image](https://user-images.githubusercontent.com/73840223/108612339-c3588300-7422-11eb-8338-2042a77fef82.png)
