### PR TITLE
doc / add link to delete-api

### DIFF
--- a/content/operation/command-ref.mdx
+++ b/content/operation/command-ref.mdx
@@ -110,6 +110,12 @@ Enter the Websocket Address of your Ethereum Node >>>
 Wallet 0xC20...8bFa connected to hummingbot.
 ```
 
+<Callout
+  type="tip"
+  body="Related article: [How to delete or remove exchange API keys?] "
+  link={["https://hummingbot.zendesk.com/hc/en-us/articles/900005194643-Delete-API-keys"]}
+/>
+
 ## create
 
 Create a new bot and walk through the strategy configuration.


### PR DESCRIPTION
Added tip callout for `How to delete or remove exchange API keys` and added a link to the Zendesk guide 