### PR TITLE
fix / broken link and fix typo

### DIFF
--- a/content/exchange-connectors/dydx.mdx
+++ b/content/exchange-connectors/dydx.mdx
@@ -55,4 +55,4 @@ Minimum order sizes will vary by trading pair. dYdX has a minimum order of 1 ETH
 
 By default, trading fees are 0% for market makers and 0.3% for takers on dYdX. See article below for more details.
 
-- [Fee Schedule](https://help.dydx.exchange/en/articles/3784235-trade-fees-on-dydx)
+- [Trader Fees](https://help.dydx.exchange/en/articles/4800191-are-there-fees-to-using-dydx)


### PR DESCRIPTION
-Fixed broken link for dYdX Trader Fees 
![image](https://user-images.githubusercontent.com/78310937/109024585-e0c66f00-76f8-11eb-82fa-b2cc943d9803.png)

