### PR TITLE
doc / add use_oracle_conversion_rate

### DIFF
--- a/content/strategies/arbitrage.mdx
+++ b/content/strategies/arbitrage.mdx
@@ -81,7 +81,21 @@ Minimum profitability target required to execute trades.
   response=">>> "
 />
 
-<Callout type="tip" body="For autocomplete inputs during configuration, when going through the command line config process, pressing `<TAB>` at a prompt will display valid available inputs." />
+### `use_oracle_conversion_rate`
+
+Rate oracle conversion is used to compute the rate of a certain market pair using collection of prices from either Binance or Coingecko.
+
+If enabled, when the trading pair symbols mismatch, the bot will use a real-time conversion rate from the oracle.
+For example, if markets are set to trade for `LINK-USDT` and `LINK-USDC`, the bot will use the oracle conversion rate between `USDT` and `USDC`.
+
+You can also edit it from `config_global.yml` to change the `rate_oracle_source`.
+
+** Prompt: **
+
+<Callout
+  type="tip"
+  body="For autocomplete inputs during configuration, when going through the command line config process, pressing `<TAB>` at a prompt will display valid available inputs."
+/>
 
 ## Advanced Parameters
 

--- a/content/strategies/arbitrage.mdx
+++ b/content/strategies/arbitrage.mdx
@@ -92,6 +92,11 @@ You can also edit it from `config_global.yml` to change the `rate_oracle_source`
 
 ** Prompt: **
 
+<Prompt
+  prompt="Do you want to use rate oracle on unmatched trading pairs? (Yes/No)"
+  response=">>>"
+/>
+
 <Callout
   type="tip"
   body="For autocomplete inputs during configuration, when going through the command line config process, pressing `<TAB>` at a prompt will display valid available inputs."

--- a/content/strategies/cross-exchange-market-making.mdx
+++ b/content/strategies/cross-exchange-market-making.mdx
@@ -11,7 +11,10 @@ import Prompt from "../../src/components/Prompt";
 
 Cross exchange market making is described in [Strategies](overview), with a further discussion in the Hummingbot [white paper](https://hummingbot.io/hummingbot.pdf).
 
-<Callout type="warning" body="Updates to strategy — The cross exchange market making strategy has been updated as of v0.15.0, so that it will always place the order at the minimum profitability level. If the sell price for the specified volume on the taker exchange is 100, and you set the min_profitability as 0.01, it will place the maker buy order at 99. The top depth tolerance is also now specified by the user in base currency units. Please do not use old configuration files for running this strategy." />
+<Callout
+  type="warning"
+  body="Updates to strategy — The cross exchange market making strategy has been updated as of v0.15.0, so that it will always place the order at the minimum profitability level. If the sell price for the specified volume on the taker exchange is 100, and you set the min_profitability as 0.01, it will place the maker buy order at 99. The top depth tolerance is also now specified by the user in base currency units. Please do not use old configuration files for running this strategy."
+/>
 
 ### Schematic
 
@@ -139,7 +142,26 @@ An amount expressed in base currency of maximum allowable order size.
   response=""
 />
 
-<Callout type="tip" body="For autocomplete inputs during configuration, when going through the command line config process, pressing `<TAB>` at a prompt will display valid available inputs." />
+### `use_oracle_conversion_rate`
+
+Rate oracle conversion is used to compute the rate of a certain market pair using collection of prices from either Binance or Coingecko.
+
+If enabled, when the trading pair symbols mismatch, the bot will use a real-time conversion rate from the oracle.
+For example, if markets are set to trade for `LINK-USDT` and `LINK-USDC`, the bot will use the oracle conversion rate between `USDT` and `USDC`.
+
+You can also edit it from `config_global.yml` to change the `rate_oracle_source`.
+
+** Prompt: **
+
+<Prompt
+  prompt="Do you want to use rate oracle on unmatched trading pairs? (Yes/No)"
+  response=">>>"
+/>
+
+<Callout
+  type="tip"
+  body="For autocomplete inputs during configuration, when going through the command line config process, pressing `<TAB>` at a prompt will display valid available inputs."
+/>
 
 ## Advanced Parameters
 


### PR DESCRIPTION
-Add `use_oracle_conversion_rate` command on Arbitrage and XEMM Strategy. 

![image](https://user-images.githubusercontent.com/78310937/113405156-eee46b00-93db-11eb-8490-732396099af1.png)
