### PR TITLE
doc / Remove extra character on balance limit

### DIFF
--- a/content/features/balance-limit.mdx
+++ b/content/features/balance-limit.mdx
@@ -68,13 +68,13 @@ Another sell order gets filled, the available balance now shows 41.2069. Plus th
 
 ![sell filled2](img/sell_filled2.png)
 
-After the two sell orders gets filled the remaining available balance in ETH is 0.0137 equivalent to $8.17. It means that after the next `order_refresh_time` it won't create sell order because the minimum order amount is $11.
+After the two sell orders gets filled the remaining available balance in ETH is 0.0137 equivalent to \$8.17. It means that after the next `order_refresh_time` it won't create sell order because the minimum order amount is \$11.
 
 ![buy order](img/buy_order.png)
 
 ![buy order1](img/buy_order1.png)
 
-Same process as the scenario above. After the two buy orders gets filled the remaining available balance in USDT is 7.5317 equivalent to $7.53. It means that after the next `order_refresh_time` it won't create buy order because the minimum order amount is $11.
+Same process as the scenario above. After the two buy orders gets filled the remaining available balance in USDT is 7.5317 equivalent to \$7.53. It means that after the next `order_refresh_time` it won't create buy order because the minimum order amount is \$11.
 
 ![buy order buy](img/buy_order_buy.png)
 


### PR DESCRIPTION
- Updated the [Balance Limit doc](https://docs.hummingbot.io/features/balance-limit/#gatsby-focus-wrapper) to fix a couple of skewed sentences.
![image](https://user-images.githubusercontent.com/81416132/114621221-11269480-9cca-11eb-96fe-9cafcd3da4e5.png)

![image](https://user-images.githubusercontent.com/81416132/114621245-1683df00-9cca-11eb-9a3a-1445451b3f42.png)
