### PR TITLE
doc / Remove extra character on inventory skew

### DIFF
--- a/content/strategies/inventory-skew.mdx
+++ b/content/strategies/inventory-skew.mdx
@@ -48,11 +48,17 @@ This expands the range of tolerable inventory level around your target base perc
 
 This function adjusts the bid and ask order amounts to limit the user's trading exposure within a defined range. This prevents the user from being over-exposed from the risks of a single side of the trade when the market keeps hitting limit orders on one side only.
 
-<Callout type="note" body="#Example#: You are market making for the `BTC-USDT` pair and have 0.667 BTC and 6000 USDT. At $6000 BTC price, your total portfolio value is $10,000 and the base asset (BTC) accounts for 40% of total value. If your target base percent is 50%, your buy orders will be increased and your sell orders will be decreased until you reach the target percent." />
+<Callout
+  type="note"
+  body="#Example#: You are market making for the `BTC-USDT` pair and have 0.667 BTC and 6000 USDT. At $6000 BTC price, your total portfolio value is $10,000 and the base asset (BTC) accounts for 40% of total value. If your target base percent is 50%, your buy orders will be increased and your sell orders will be decreased until you reach the target percent."
+/>
 
 The user specifies a target base asset percentage. Since the user's outstanding orders may change this split if they are filled, the total order size is used to define an allowable range around this target percentage. The user may expand or contract this range via a multiplier parameter.
 
-<Callout type="note" body="#Example#: You are market making for the `BTC-USDT` pair and the total value of your BTC/USDT inventory is 10 BTC. Your target base percent is 50% and each set of orders you place is 1 BTC (10% of your total portfolio). With `inventory_range_multiplier` of 1.00, your target range is 40% to 60%. With `inventory_range_multiplier` of 2.00, your target range is 30% to 70%.\*" />
+<Callout
+  type="note"
+  body="#Example#: You are market making for the `BTC-USDT` pair and the total value of your BTC/USDT inventory is 10 BTC. Your target base percent is 50% and each set of orders you place is 1 BTC (10% of your total portfolio). With `inventory_range_multiplier` of 1.00, your target range is 40% to 60%. With `inventory_range_multiplier` of 2.00, your target range is 30% to 70%.\*"
+/>
 
 If the user's base asset value goes above the upper limit, then no bid orders would be emitted. Conversely, if the user's base asset value goes below the lower limit, then no ask orders would be emitted.
 
@@ -116,7 +122,7 @@ Starting with version **0.30.0**, a [limit](/release-notes/0.30.0/#-new-command-
 
 **Without balance limit**
 
-The image below shows our total balance is around $200. To maintain a 50-50 ratio based on `inventory_target_base_pct`, the target shows a value of around $100 for the base and quote asset.
+The image below shows our total balance is around \$200. To maintain a 50-50 ratio based on `inventory_target_base_pct`, the target shows a value of around \$100 for the base and quote asset.
 
 ![inventory skew](/img/skew_without_limit.png)
 
@@ -129,7 +135,7 @@ binance:
        USDT     105.7188      50.0000
 ```
 
-Let’s say we put a $50 limit on both USDC and USDT which makes our total usable assets to $100. Notice that the target amount is now at \$50 for both sides which means, inventory skew works with respect to the total balance limit.
+Let’s say we put a \$50 limit on both USDC and USDT which makes our total usable assets to \$100. Notice that the target amount is now at \$50 for both sides which means, inventory skew works with respect to the total balance limit.
 
 ## Order Size Calculation Math
 


### PR DESCRIPTION
Updated the [Inventory Skew doc](https://docs.hummingbot.io/strategies/inventory-skew/#gatsby-focus-wrapper) to fix a couple of skewed sentences.

![image](https://user-images.githubusercontent.com/81416132/114756435-5bfee580-9d78-11eb-8ee7-e3384b783644.png)

![image](https://user-images.githubusercontent.com/81416132/114756455-602b0300-9d78-11eb-89a8-5b151cfd08e5.png)
