### PR TITLE
doc / Fixed the misspelling and removed multiple redundancies

### DIFF
--- a/content/features/paper-trade.mdx
+++ b/content/features/paper-trade.mdx
@@ -28,8 +28,8 @@ Also shows a reminder that paper trade was enabled when doing a `status` or `his
 ![papertrade3](img/paper_trade_warning.png)
 
 <Callout
-type="tip"
-body="In the event that the bot is running on paper trade and you disable it, you need to `stop` and `start` the bot to apply the changes. Make sure your Exchange APIs are connected as well when going live."
+  type="tip"
+  body="In the event that the bot is running on paper trade and you disable it, you need to `stop` and `start` the bot to apply the changes. Make sure your Exchange APIs are connected as well when going live."
 />
 
 ## Adding Paper Trade Balance
@@ -51,7 +51,7 @@ Paper account balances:
       ZRX  1000.0000
 ```
 
-When adding balances, specify the asset and balance you want by runing this command `balance paper [asset] [amount]`.
+When adding balances, specify the asset and balance you want by running this command `balance paper [asset] [amount]`.
 
 For example, we want to add 0.5 BTC and check our paper account balance to confirm.
 
@@ -76,28 +76,28 @@ Paper account balances:
 
 Here is the list of our Supported Connectors that could run `paper_trade` as of version 0.38.0.
 
-| Connector                                          |                   Status                   | Description                                                                                                                                                                             |
-| :------------------------------------------------- | :----------------------------------------: | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| [AscendEx](/exchange-connectors/ascend-ex)         | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22AscendEx%22+in%3Atitle) page for more information   |
-| [Beaxy](/exchange-connectors/beaxy)                | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [Binance](/exchange-connectors/binance)            | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [Binance US](/exchange-connectors/binance-us)      | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22binance+US%22+in%3Atitle) page for more information |
-| [Bitfinex](/exchange-connectors/bitfinex)          | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bitfinex%22+in%3Atitle) page for more information   |
-| [Bittrex Global](/exchange-connectors/bittrex)     | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bittrex%22+in%3Atitle) page for more information    |
-| [Coinbase Pro](/exchange-connectors/coinbase)      | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [Coinzoom](/exchange-connectors/coinzoom)          | <StatusCircle color="yellow" font="25px"/> | Connector is new (BETA) and may have some undiscovered issues                                                                                                                           |
-| [Crypto.com](/exchange-connectors/crypto-com)      | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22crypto.com%22+in%3Atitle) page for more information |
-| [Digifinex](/exchange-connectors/digifinex)        | <StatusCircle color="yellow" font="25px"/> | Connector is new (BETA) and may have some undiscovered issues                                                                                                                           |
-| [dYdX](/exchange-connectors/dydx)                  | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [HitBTC](/exchange-connectors/hitbtc)              | <StatusCircle color="yellow" font="25px"/> | Connector is new (BETA) and may have some undiscovered issues                                                                                                                           |
-| [Huobi Global](/exchange-connectors/huobi)         | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [Kraken](/exchange-connectors/kraken)              | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [KuCoin](/exchange-connectors/kucoin)              | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [Liquid](/exchange-connectors/liquid)              | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [Loopring](/exchange-connectors/loopring)          | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22loopring%22+in%3Atitle) page for more information   |
-| [OKEx](/exchange-connectors/okex)                  | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                           |
-| [ProBit Global](/exchange-connectors/probit)       | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bitfinex%22+in%3Atitle) page for more information   |  |
-| [ProBit Korea](/exchange-connectors/probit-korea/) | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bitfinex%22+in%3Atitle) page for more information   |  |
+| Connector                                          |                   Status                   | Description                                                                                                                                                                        |
+| :------------------------------------------------- | :----------------------------------------: | :--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [AscendEx](/exchange-connectors/ascend-ex)         | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22AscendEx%22+in%3Atitle) for more information   |
+| [Beaxy](/exchange-connectors/beaxy)                | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [Binance](/exchange-connectors/binance)            | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [Binance US](/exchange-connectors/binance-us)      | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22binance+US%22+in%3Atitle) for more information |
+| [Bitfinex](/exchange-connectors/bitfinex)          | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bitfinex%22+in%3Atitle) for more information   |
+| [Bittrex Global](/exchange-connectors/bittrex)     | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bittrex%22+in%3Atitle) for more information    |
+| [Coinbase Pro](/exchange-connectors/coinbase)      | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [Coinzoom](/exchange-connectors/coinzoom)          | <StatusCircle color="yellow" font="25px"/> | Connector is new (BETA) and may have some undiscovered issues                                                                                                                      |
+| [Crypto.com](/exchange-connectors/crypto-com)      | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22crypto.com%22+in%3Atitle) for more information |
+| [Digifinex](/exchange-connectors/digifinex)        | <StatusCircle color="yellow" font="25px"/> | Connector is new (BETA) and may have some undiscovered issues                                                                                                                      |
+| [dYdX](/exchange-connectors/dydx)                  | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [HitBTC](/exchange-connectors/hitbtc)              | <StatusCircle color="yellow" font="25px"/> | Connector is new (BETA) and may have some undiscovered issues                                                                                                                      |
+| [Huobi Global](/exchange-connectors/huobi)         | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [Kraken](/exchange-connectors/kraken)              | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [KuCoin](/exchange-connectors/kucoin)              | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [Liquid](/exchange-connectors/liquid)              | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [Loopring](/exchange-connectors/loopring)          | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22loopring%22+in%3Atitle) for more information   |
+| [OKEx](/exchange-connectors/okex)                  | <StatusCircle color="green" font="25px"/>  | Connector is working properly and safe to use                                                                                                                                      |
+| [ProBit Global](/exchange-connectors/probit)       | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bitfinex%22+in%3Atitle) for more information   |  |
+| [ProBit Korea](/exchange-connectors/probit-korea/) | <StatusCircle color="yellow" font="25px"/> | Connector has one or more reported issues. Refer to our [Github page](https://github.com/CoinAlpha/hummingbot/issues?q=is%3Aopen+%22bitfinex%22+in%3Atitle) for more information   |  |
 
 <Callout
   type="note"


### PR DESCRIPTION
- Updated the [Paper Trade doc](https://docs.hummingbot.io/features/paper-trade/) to fix one misspelling and few redundancies.

![image](https://user-images.githubusercontent.com/81416132/114931619-19aad680-9e54-11eb-88c2-2d2eb8291eba.png)

![image](https://user-images.githubusercontent.com/81416132/114931630-1d3e5d80-9e54-11eb-90e7-776d157a0a7a.png)

![image](https://user-images.githubusercontent.com/81416132/114931648-22031180-9e54-11eb-9341-88adca3279cd.png)