### PR TITLE
doc / fix broken link

### DIFF
--- a/content/release-notes/0.30.0.mdx
+++ b/content/release-notes/0.30.0.mdx
@@ -88,4 +88,4 @@ This will also allow running multiple windows of Hummingbot via binary without e
 
 - Added `test_limit_maker_rejections` and `test_limit_makers_unfilled` - to test new LIMIT_MAKER order type.
 
-See [Building Connectors](/developer/tutorial/#building-connectors) for details.
+See [Building Connectors](/developer/overview/) for details.


### PR DESCRIPTION
Fix broken link on v30 release notes, `building connector`