### PR TITLE
doc / fix broken link

### DIFF
--- a/content/release-notes/0.19.0.mdx
+++ b/content/release-notes/0.19.0.mdx
@@ -16,7 +16,7 @@ title: "Version 0.19.0"
 
 - Tutorial for creating custom strategies now has its own dedicated section. It is currently a work-in-progress but you can check out the initial parts [here](/developer/build-strategy/).
 - [Architecture](/developer/architecture/) section that includes additional details for adding new connectors.
-- Added detailed examples to [Building Connectors](/developer/tutorial/) in using aioconsole for testing.
+- Added detailed examples to [Building Connectors](/developer/overview/) in using aioconsole for testing.
 
 ## 🐞 Other bug fixes and miscellaneous updates
 


### PR DESCRIPTION
Ran online broken-link checker and fixed `building connectors` link from release notes v19