### PR TITLE
fix / relink developing tutorial doc

### DIFF
--- a/content/release-notes/0.17.0.mdx
+++ b/content/release-notes/0.17.0.mdx
@@ -18,7 +18,7 @@ We redesigned how Hummingbot analyzes performance so that events unrelated to Hu
 
 We published a developer tutorial on building custom strategies and documentation for the **Perform Trade** strategy.
 
-- [Developer Tutorial](/developer/tutorial/#building-connectors)
+- [Developer Tutorial](https://docs.hummingbot.io/developer/exchange-connector-tutorial/)
 - [Perform Trade Strategy](/developer/build-strategy/#perform-trade-strategy)
 
 ## 📚Log file management / data storage


### PR DESCRIPTION
-Fixed broken link for "Developer Tutorial" 
![image](https://user-images.githubusercontent.com/78310937/115562925-9113b680-a2e9-11eb-87ce-5c7cedfb4b72.png)
