### PR TITLE
doc / fix broken links 

### DIFF
--- a/content/release-notes/0.16.0.mdx
+++ b/content/release-notes/0.16.0.mdx
@@ -27,7 +27,7 @@ This is a configurable parameter, so users can turn this behavior off if they li
 As part of our ongoing efforts to make the Hummingbot code base more understandable and easier to use for developers, we have published guidelines for community-contributed exchange connectors, as well as more documentation on the order lifecycle:
 
 - [Guidelines and expectations for community developers building exchange connectors](/developer/exchange-connector-tutorial/#order-lifecycle-flowchart)
-- [Order lifecycle and market events for connectors](/developer/tutorial/#order-lifecycle-and-market-events)
+- [Order lifecycle and market events for connectors](/developer/exchange-connector-tutorial/#order-lifecycle-and-market-events)
 - [Changed MarketSymbolPair to MarketTradingPairTuple in strategies for creating and cancelling orders](/developer/strategies-overview/#creating-and-cancelling-orders)
 
 ## 🐞 Other bug fixes and miscellaneous updates


### PR DESCRIPTION
Added link to `Order lifecycle and market events for connectors` on version 0.16.0