### PR TITLE
doc / added warning callouts for CELO, protocol connectors and dydx exchanges

### DIFF
--- a/content/exchange-connectors/dydx-perpetual.mdx
+++ b/content/exchange-connectors/dydx-perpetual.mdx
@@ -32,7 +32,11 @@ Private keys and API keys are stored locally for the operation of the Hummingbot
   ]}
 />
 
-### Creating dYdX Perpetual API keys
+<Callout
+  type="warning"
+  body="Currently, [dydx] and [dydx-perpetual] do not work on Binary Installers. It can only be used when running Hummingbot from source or with Docker."
+  link={["/exchange-connectors/dydx/", "/exchange-connectors/dydx-perpetual/"]}
+/>
 
 ## Miscellaneous Info
 

--- a/content/exchange-connectors/dydx.mdx
+++ b/content/exchange-connectors/dydx.mdx
@@ -37,12 +37,8 @@ Error: DydxAPIError(status_code=400)(response={'errors': [{'name': 'AccountNotFo
 
 <Callout
   type="warning"
-  body="Currently [dydx], [terra], and [loopring] don't work on Binary Installers. It can only be used when running Hummingbot from source or with Docker."
-  link={[
-    "/exchange-connectors/dydx/",
-    "/protocol-connectors/terra",
-    "/exchange-connectors/loopring/",
-  ]}
+  body="Currently, [dydx] and [dydx-perpetual] do not work on Binary Installers. It can only be used when running Hummingbot from source or with Docker."
+  link={["/exchange-connectors/dydx/", "/exchange-connectors/dydx-perpetual/"]}
 />
 
 ## Miscellaneous Info

--- a/content/protocol-connectors/balancer.mdx
+++ b/content/protocol-connectors/balancer.mdx
@@ -6,6 +6,15 @@ import Callout from "../../src/components/Callout";
 
 Balancer is an automated portfolio manager, liquidity provider, and price sensor, in other words, a decentralized finance protocol based on Ethereum that allows automatic market making.
 
+<Callout
+  type="warning"
+  body="Currently, [Balancer] could not be used on Binary Installers since it would need a [gateway] connection for it to work. It can only be used when running Hummingbot from source or with Docker."
+  link={[
+    "/protocol-connectors/balancer",
+    "https://docs.hummingbot.io/gateway/installation/#what-is-hummingbot-gateway",
+  ]}
+/>
+
 ## Prerequisites
 
 - Ethereum wallet (refer to our guide [here](/operation/adv-command-ref/#setup-ethereum-wallet))
@@ -32,7 +41,7 @@ After adding your Ethereum wallet and node in Hummingbot, follow the guide in th
 - [Hummingbot Gateway Installation](/gateway/installation/)
 
 <Callout
-type="note"
-body="For setting up gas estimator, you can check our [ETH Gas Station] for more info"
-link={["/gateway/installation/#eth-gas-station"]}
+  type="note"
+  body="For setting up gas estimator, you can check our [ETH Gas Station] for more info"
+  link={["/gateway/installation/#eth-gas-station"]}
 />

--- a/content/protocol-connectors/perp-fi.mdx
+++ b/content/protocol-connectors/perp-fi.mdx
@@ -15,6 +15,15 @@ import Callout from "../../src/components/Callout";
 
 Perpetual Protocol is a decentralized perpetual contract trading protocol for every asset, with a Uniswap-inspired Virtual Automated Market Makers (Virtual AMMs) and a built-in Staking Reserve which backs and secures the Virtual AMMs.
 
+<Callout
+  type="warning"
+  body="Currently, [Perpetual Finance] could not be used on Binary Installers since it would need a [gateway] connection for it to work. It can only be used when running Hummingbot from source or with Docker."
+  link={[
+    "/protocol-connectors/perp-fi/",
+    "https://docs.hummingbot.io/gateway/installation/#what-is-hummingbot-gateway",
+  ]}
+/>
+
 ## Prerequisites
 
 - Ethereum wallet (refer to our guide [here](/operation/adv-command-ref/#setup-ethereum-wallet))

--- a/content/protocol-connectors/terra.mdx
+++ b/content/protocol-connectors/terra.mdx
@@ -10,6 +10,14 @@ It runs on a Tendermint Delegated Proof of Stake algorithm and Cosmos SDK. It is
 
 Source: https://medium.com/stakin/what-is-terra-money-8eb1dcb314d2
 
+<Callout
+  type="warning"
+  body="Currently, [Terra] could not be used on Binary Installers since it would need a [gateway] connection for it to work. It can only be used when running Hummingbot from source or with Docker."
+  link={[
+    "/protocol-connectors/terra",
+    "https://docs.hummingbot.io/gateway/installation/#what-is-hummingbot-gateway",
+  ]}
+/>
 
 ## Prerequisites
 
@@ -35,4 +43,3 @@ Source: https://medium.com/stakin/what-is-terra-money-8eb1dcb314d2
 4. Create and run an `amm_arb` strategy to use the Terra connector
 
 ![](img/connect-terra.gif)
-

--- a/content/protocol-connectors/uniswap.mdx
+++ b/content/protocol-connectors/uniswap.mdx
@@ -10,6 +10,15 @@ Also unlike most exchanges, which match buyers and sellers to determine prices a
 
 Source: https://decrypt.co/resources/what-is-uniswap
 
+<Callout
+  type="warning"
+  body="Currently, [Uniswap] could not be used on Binary Installers since it would need a [gateway] connection for it to work. It can only be used when running Hummingbot from source or with Docker."
+  link={[
+    "/protocol-connectors/uniswap/",
+    "https://docs.hummingbot.io/gateway/installation/#what-is-hummingbot-gateway",
+  ]}
+/>
+
 ## Prerequisites
 
 - Ethereum wallet (refer to our guide [here](/operation/adv-command-ref/#setup-ethereum-wallet))
@@ -36,7 +45,7 @@ After adding your Ethereum wallet and node in Hummingbot, follow the guide in th
 - [Hummingbot Gateway Installation](/gateway/installation/)
 
 <Callout
-type="note"
-body="For setting up gas estimator, you can check our [ETH Gas Station] for more info"
-link={["/gateway/installation/#eth-gas-station"]}
+  type="note"
+  body="For setting up gas estimator, you can check our [ETH Gas Station] for more info"
+  link={["/gateway/installation/#eth-gas-station"]}
 />

--- a/content/strategies/celo-arb.mdx
+++ b/content/strategies/celo-arb.mdx
@@ -9,6 +9,15 @@ import Prompt from "../../src/components/Prompt";
 
 **Updated as of v0.28.1**
 
+<Callout
+  type="warning"
+  body="The Celo Arbitrage Strategy could not be used on Binary Installers since it would need a [gateway] connection for it to work. It can only be used when running Hummingbot from source or with Docker."
+  link={[
+    "/protocol-connectors/balancer",
+    "https://docs.hummingbot.io/gateway/installation/#what-is-hummingbot-gateway",
+  ]}
+/>
+
 ## Prerequisites
 
 Since Celo is a blockchain protocol, in addition to the normal inventory requirements, you will need access to a Celo node and the `celo-cli` command line tool in the same machine in which you are running the Hummingbot client.
@@ -24,7 +33,11 @@ Celo nodes allow the Hummingbot client to interact with the Celo blockchain by c
 
 Follow the [Celo documentation](https://docs.celo.org/getting-started/mainnet/running-a-full-node-in-mainnet) to install and run a full node. Note that the node must be synced in order for the `celo-arb` strategy to run.
 
-<Callout type="tip" body="Ultra-light sync mode — The `celo-arb` strategy works with Celo node running in 'ultra-light' mode, which is much faster to sync. See our [Quickstart] for instructions on how to start a node in ultra-light mode." link={["https://hummingbot.io/academy/celo-arb/"]} />
+<Callout
+  type="tip"
+  body="Ultra-light sync mode — The `celo-arb` strategy works with Celo node running in 'ultra-light' mode, which is much faster to sync. See our [Quickstart] for instructions on how to start a node in ultra-light mode."
+  link={["https://hummingbot.io/academy/celo-arb/"]}
+/>
 
 ### `celo-cli` CLI tool
 
@@ -112,8 +125,10 @@ export CELO_ACCOUNT_ADDRESS=<YOUR-ACCOUNT-ADDRESS>
 
 ```
 
-<Callout type="note" body="Make sure that you save the address and password of the new Celo account address you created. You will need it later." />
-
+<Callout
+  type="note"
+  body="Make sure that you save the address and password of the new Celo account address you created. You will need it later."
+/>
 
 Instead, run the following command to start an **ultra-light node** rather than a full node:
 


### PR DESCRIPTION
In line with the recent release of DyDx Perpetual, The QA testers suggested on adding some "warning" callouts for our supported exchanges/strategy that couldn't be used on Binary installers.

-Also deleted the "Creating dYdX Perpetual API keys" since we have no data yet rather than leaving it blank. 

-
![image](https://user-images.githubusercontent.com/78310937/118738350-6fbad180-b879-11eb-8b9a-71ef61c1b7f2.png)

-dydx spot and perpetual. 
![image](https://user-images.githubusercontent.com/78310937/118738369-79dcd000-b879-11eb-85bf-7922adb2c6cc.png)

-Balancer
![image](https://user-images.githubusercontent.com/78310937/118738389-82cda180-b879-11eb-909b-809338732d4b.png)

-Perpetual Finance
![image](https://user-images.githubusercontent.com/78310937/118738449-a395f700-b879-11eb-9f89-9fa5c58351a7.png)

-Terra
![image](https://user-images.githubusercontent.com/78310937/118738459-adb7f580-b879-11eb-8ba3-aef1d53557cb.png)

-Lastly, Uniswap.
![image](https://user-images.githubusercontent.com/78310937/118738468-b7415d80-b879-11eb-8a49-ca3c3593e90f.png)


