### PR TITLE
doc / dydx perpetuals edits

### DIFF
--- a/content/exchange-connectors/dydx-perpetual.mdx
+++ b/content/exchange-connectors/dydx-perpetual.mdx
@@ -5,22 +5,52 @@ description: About dYdX Perpetual Exchange Connector
 
 import Callout from "../../src/components/Callout";
 
-dYdX is a leading decentralized exchange that currently supports perpetual, margin trading, and spot trading, as well as lending, and borrowing. dYdX runs on smart contracts on the Ethereum blockchain, and allows users to trade with no intermediaries.
+dYdX is a leading decentralized exchange that currently supports perpetual, margin trading, spot trading, lending, and borrowing. dYdX runs on smart contracts on the Ethereum blockchain, and allows users to trade with no intermediaries.
 
-## Using the connector
+## Prerequisites
 
-Because dYdX perpetual is a decentralized exchange, you will need to create API keys, stark keys and ethereum wallet. See below for information on how to create these:
+### Supported Installation Types
 
-Here's the [link](https://help.dydx.exchange/en/articles/5108497-how-to-deposit-usdc-or-any-erc-20-token-into-your-l2-perpetual-account?utm_content=article_5108497) on how to signup and deposit on dYdX perpetual.
+Currently, this connector does not work on binary installation. Running Hummingbot via Docker or from source to use this connector.
 
-```
-Enter your dydx Perpetual API key >>>
-Enter your dydx Perpetual API secret >>>
-Enter your dydx Perpetual passphrase >>>
-Enter your dydx Perpetual API account_number >>>
-Enter your stark private key >>>
-Enter your ethereum wallet address >>>
-```
+- Install via Docker: [Linux](/installation/linux/#install-via-docker) | [Windows](/installation/windows/#install-via-docker) | [macOS](/installation/mac/#install-via-docker) | [Raspberry Pi](/installation/raspberry/)
+- Install from source: [Linux](/installation/linux/#install-from-source) | [Windows](/installation/windows/#install-from-source) | [macOS](/installation/mac/#install-from-source) | [Raspberry Pi](/installation/raspberry/#install-from-source)
+
+### API Credentials and Stark Key
+
+1. Connect your Ethereum wallet to dydx Perpetual
+   - [How to deposit USDC or any ERC-20 token into your L2 Perpetual account](https://help.dydx.exchange/en/articles/5108497-how-to-deposit-usdc-or-any-erc-20-token-into-your-l2-perpetual-account?utm_content=article_5108497)
+2. You need the following to connect Hummingbot to the exchange:
+   - API key
+   - API secret key
+   - Passphrase
+   - Account number
+   - Stark private key
+
+API credentials and a stark private key can be obtained programmatically using their documentation:
+
+- [Recover Default API Credentials](https://docs.dydx.exchange/?python#recover-default-api-credentials)
+- [Derive StarkKey](https://docs.dydx.exchange/?python#derive-starkkey)
+
+Alternatively, you can follow these steps to get the required credentials:
+
+1. From the dydx Perpetuals exchange, right-click anywhere on your web browser, and select **Inspect** to open Developer Tools
+2. Go to Application > Local Storage > https://trade.dydx.exchange
+3. Select **STARK_KEY_PAIRS** and click the drop-down next to your wallet address to get the stark private key
+4. Select **API_KEY_PAIRS** and click the drop-down next to your wallet address to get the API key, secret key, and passphrase
+
+### Ethereum Wallet Address
+
+You can use any Ethereum wallet address to connect to Hummingbot. If you're new to this and unsure which one to use, most of our users are on MetaMask.
+
+- [MetaMask - Getting Started](https://metamask.io/faqs.html)
+
+## Connecting to Exchange
+
+1. From Hummingbot, run `connect dydx_perpetual` command
+2. Enter the required dydx Perpetual credentials on each prompt
+3. Enter your Ethereum wallet address
+4. Hummingbot will confirm when you have successfully connected to the exchange
 
 Private keys and API keys are stored locally for the operation of the Hummingbot client only. At no point will private or API keys be shared to CoinAlpha or be used in any way other than to authorize transactions required for the operation of Hummingbot.
 
@@ -32,20 +62,14 @@ Private keys and API keys are stored locally for the operation of the Hummingbot
   ]}
 />
 
-<Callout
-  type="warning"
-  body="Currently, [dydx] and [dydx-perpetual] do not work on Binary Installers. It can only be used when running Hummingbot from source or with Docker."
-  link={["/exchange-connectors/dydx/", "/exchange-connectors/dydx-perpetual/"]}
-/>
+## Minimum Order Sizes
 
-## Miscellaneous Info
+Their help article below provides information on the minimum order size per asset.
 
-### Minimum Order Sizes
+- [Minimum Trade Sizes](https://help.dydx.exchange/en/articles/4798055-what-is-the-minimum-order-size-on-perpetuals)
 
-Minimum order sizes will vary by trading pair. Check out this [link](https://help.dydx.exchange/en/articles/4798055-what-is-the-minimum-order-size-on-perpetuals) for more information.
+## Transaction Fees
 
-### Transaction Fees
-
-By default, trading fees are 0.050% for market makers and 0.200% for takers on dYdX. See article below for more details.
+By default, trading fees are 0.05% for market makers and 0.20% for takers on dYdX. See the article below for more details.
 
 - [Perpetual Trade Fees](https://help.dydx.exchange/en/articles/4798040-perpetual-trade-fees)

--- a/content/exchange-connectors/dydx-perpetual.mdx
+++ b/content/exchange-connectors/dydx-perpetual.mdx
@@ -11,7 +11,7 @@ dYdX is a leading decentralized exchange that currently supports perpetual, marg
 
 ### Supported Installation Types
 
-Currently, this connector does not work on binary installation. Running Hummingbot via Docker or from source to use this connector.
+Currently, this connector does not work on binary installation. Install Hummingbot via Docker or from source to use this connector.
 
 - Install via Docker: [Linux](/installation/linux/#install-via-docker) | [Windows](/installation/windows/#install-via-docker) | [macOS](/installation/mac/#install-via-docker) | [Raspberry Pi](/installation/raspberry/)
 - Install from source: [Linux](/installation/linux/#install-from-source) | [Windows](/installation/windows/#install-from-source) | [macOS](/installation/mac/#install-from-source) | [Raspberry Pi](/installation/raspberry/#install-from-source)


### PR DESCRIPTION
- Added instructions how to obtain API credentials and stark key
- Added prerequisites on using the connector (supported installation types, API credentials, Ethereum wallet address)
- Changed from "Using the connector" to "Connecting to Exchange" because it's the only content

Preview here: https://deploy-preview-405--docs-hb-v3.netlify.app/exchange-connectors/dydx-perpetual/