### PR TITLE
docs/add account number 0 to dydxperpetual

### DIFF
--- a/content/exchange-connectors/dydx-perpetual.mdx
+++ b/content/exchange-connectors/dydx-perpetual.mdx
@@ -24,7 +24,7 @@ Currently, this connector does not work on binary installation. Install Hummingb
    - API key
    - API secret key
    - Passphrase
-   - Account number
+   - Account number (Always set **account_number** to **0** for now)
    - Stark private key
 
 API credentials and a stark private key can be obtained programmatically using their documentation:

--- a/content/exchange-connectors/dydx-perpetual.mdx
+++ b/content/exchange-connectors/dydx-perpetual.mdx
@@ -24,7 +24,7 @@ Currently, this connector does not work on binary installation. Install Hummingb
    - API key
    - API secret key
    - Passphrase
-   - Account number (Always set **account_number** to **0** for now)
+   - Account number (Always set value to **0** for now)
    - Stark private key
 
 API credentials and a stark private key can be obtained programmatically using their documentation:


### PR DESCRIPTION
Added an account number set to 0 for now in the dydx perpetual documentation. 