### PR TITLE
fix / update binary and mac installer on v.39.0

### DIFF
--- a/content/release-notes/0.39.0.mdx
+++ b/content/release-notes/0.39.0.mdx
@@ -6,7 +6,7 @@ import Callout from "../../src/components/Callout";
 
 _Released on May 18, 2021_
 
-- **Download Installer**: [Windows](https://dist.hummingbot.io/hummingbot_v0.38.0_setup.exe) | [macOS](https://dist.hummingbot.io/hummingbot_v0.38.0.dmg)
+- **Download Installer**: [Windows](https://dist.hummingbot.io/hummingbot_v0.39.0_setup.exe) | [macOS](https://dist.hummingbot.io/hummingbot_v0.39.0.dmg)
 - **Install via Docker**: [Linux](/installation/linux/#install-via-docker) | [Windows](/installation/windows/#install-via-docker) | [macOS](/installation/mac/#install-via-docker)| [Raspberry Pi](/installation/raspberry/)
 
 ---


### PR DESCRIPTION
A twitter user reported that the Binary Installer for Windows/Mac that is linked in our "May 2021 (v0.39.0)" Docs route you over to our previous release (Version 38.0) download.

![image](https://user-images.githubusercontent.com/78310937/119181779-a6c0fb00-baa4-11eb-815b-78c618bc7e83.png)

Tried to check it on the production site and confirmed that it downloads the `hummingbot_v0.38.0_setup.exe`

![image](https://user-images.githubusercontent.com/78310937/119182106-1800ae00-baa5-11eb-8f62-6200ed26bb9e.png)

----
-Fix the link in the release version 0.39.0 

![image](https://user-images.githubusercontent.com/78310937/119183114-37e4a180-baa6-11eb-9075-bab1ba7e1e66.png)

