### PR TITLE
doc / remove recursive flag from rm command

### DIFF
--- a/content/operation/docker-commands.mdx
+++ b/content/operation/docker-commands.mdx
@@ -38,7 +38,7 @@ Copy the commands below and paste them into the shell or terminal to delete the 
 ### Linux
 
 ```Linux
-rm -rf create.sh start.sh update.sh
+rm -f create.sh start.sh update.sh
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh
 wget https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh
@@ -48,7 +48,7 @@ chmod a+x *.sh
 ### MacOS
 
 ```MacOS
-rm -rf create.sh start.sh update.sh
+rm -f create.sh start.sh update.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/create.sh -o create.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/start.sh -o start.sh
 curl https://raw.githubusercontent.com/CoinAlpha/hummingbot/development/installation/docker-commands/update.sh -o update.sh


### PR DESCRIPTION
I would like to suggest removing the -r (recursive) flag as it is not needed since the arguments should only be files.  

It is a bad habit to default to appending the `-rf` flags to `rm`.  Especially in cases where users are encouraged to copy and paste.   

Apologies if this submission isn't the preferred method for minor documentation tweaks.  Please let me know if you prefer different channels to raise/suggest changes like this.