### PR TITLE
fix / fixed broken link for defipulse

### DIFF
--- a/content/gateway/installation.mdx
+++ b/content/gateway/installation.mdx
@@ -85,22 +85,21 @@ In case the port number used by Gateway is not set to the default value of `5000
 
 ![](img/config-gateway-api-port.gif)
 
-
 ## ETH Gas Station
 
 <Callout
-type="note"
-body="As of version 0.38.0, ethgasstation_gas_enabled has been removed from the hummingbot client and added to the parameters when setting up gateway."
+  type="note"
+  body="As of version 0.38.0, ethgasstation_gas_enabled has been removed from the hummingbot client and added to the parameters when setting up gateway."
 />
 
-Users have the option to use and configure DeFI Pulse gas price as the gas estimator. 
+Users have the option to use and configure DeFI Pulse gas price as the gas estimator.
 
-1. Sign up for a free account on [DeFi Pulse Data](data.defipulse.com)
+1. Sign up for a free account on [DeFi Pulse Data](https://data.defipulse.com)
 2. Get your API key - once you log into DeFi Pulse Data, your API key can be found on the right side of the Dashboard. Click the copy button to copy your API Key.
 
 ![](img/defipulse-2.png)
 
-When setting up your Hummingbot gateway, you will be ask if you want to enable ETH Gas price. If yes, 
+When setting up your Hummingbot gateway, you will be ask if you want to enable ETH Gas price. If yes,
 
 1. You would need to enter the DeFI pulse API key
 2. Enter gas level you want to use for ETH transactions


### PR DESCRIPTION
-Applied a fix on the DeFi Pulse Data link 
 
![image](https://user-images.githubusercontent.com/78310937/119399919-1389fe80-bd0c-11eb-9161-1f5bebf220a3.png)

- Now routes you over to the proper DeFi Pulse Data link 

![image](https://user-images.githubusercontent.com/78310937/119400143-51872280-bd0c-11eb-87de-ee0aa7c7fd4a.png)
