### PR TITLE
doc/broken links fix continuation

### DIFF
--- a/content/operation/config-files.mdx
+++ b/content/operation/config-files.mdx
@@ -4,6 +4,8 @@ title: Create or Import Config Files
 
 import Callout from "../../src/components/Callout";
 
+import Prompt from "../../src/components/Prompt";
+
 ## Creating a new strategy file
 
 Run `create` command and answer the prompts to configure your bot's behavior depending on the strategy you want to use.
@@ -89,3 +91,51 @@ You can also skip the prompt by running `import [file_name]` command.
   type="tip"
   body="Press #TAB# to scroll through the auto-complete selections."
 />
+
+## Autofill import
+
+Choose between `start` and `config` after importing a strategy file. This will be applicable for all imported strategies.
+
+** Prompt: **
+
+<Prompt
+  prompt="What to auto-fill in the prompt after each import command? (start/config)"
+  response=">>>"
+/>
+
+**Sample usage**
+
+`autofill_import = start`
+
+```
+>>>`import conf_pure_mm_1.yml`
+Configuration from conf_pure_mm_1.yml file is imported.
+
+Preliminary checks:
+ - Exchange check: All connections confirmed.
+ - Strategy check: All required parameters confirmed.
+ -All checks: Confirmed.
+
+Enter "start" to start market making
+
+>>> start
+
+```
+
+Here's an example if using the config command
+`autofill_import = config`
+
+```
+>>>`import conf_pure_mm_1.yml`
+Configuration from conf_pure_mm_1.yml file is imported.
+
+Preliminary checks:
+ - Exchange check: All connections confirmed.
+ - Strategy check: All required parameters confirmed.
+ -All checks: Confirmed.
+
+Enter "start" to start market making
+
+>>> config
+
+```

--- a/content/operation/keys-wallets-nodes.mdx
+++ b/content/operation/keys-wallets-nodes.mdx
@@ -94,9 +94,42 @@ To import your wallet using its JSON keyfile:
 
 When you import a wallet with Hummingbot, a JSON file named `key_file_[address].json` is created in the `/conf` directory. This JSON keyfile contains the encrypted private key of your wallet and can be imported into other dApps.
 
-#### Private key
+### Export Keys
 
 Within the Hummingbot CLI, you can use the `export_private_key` command to display the private key associated with a wallet address. You can import your wallet to dApps like Metamask and MyCrypto using this private key as well.
+
+### `export keys`
+
+Displays API keys, secret keys and wallet private key in the command output pane.
+
+```
+>>>  export keys
+
+Enter your password >>> *****
+
+Warning: Never disclose API keys or private keys. Anyone with your keys can steal any assets held in your account.
+
+API keys:
+binance_api_key:
+binance_api_secret:
+
+Ethereum wallets:
+Public address:
+Private key:
+
+```
+
+### `export trades`
+
+Exports all trades in the current session to a .csv file.
+
+```
+>>>  export trades
+
+Enter a new csv file name >>> trade_list
+Successfully exported trades to logs/trade_list.csv
+
+```
 
 ## Setup Ethereum Nodes
 

--- a/content/operation/keys-wallets-nodes.mdx
+++ b/content/operation/keys-wallets-nodes.mdx
@@ -96,8 +96,6 @@ When you import a wallet with Hummingbot, a JSON file named `key_file_[address].
 
 ### Export Keys
 
-Within the Hummingbot CLI, you can use the `export_private_key` command to display the private key associated with a wallet address. You can import your wallet to dApps like Metamask and MyCrypto using this private key as well.
-
 ### `export keys`
 
 Displays API keys, secret keys and wallet private key in the command output pane.

--- a/content/operation/strategy-autostart.mdx
+++ b/content/operation/strategy-autostart.mdx
@@ -129,5 +129,5 @@ Where
 `CONFIG_PASSWORD` is the config password
 
 - More information on strategy can be found in [Strategy](/strategies/overview).
-- More information on configuration file name can be found in [Configuring Hummingbot](/operation/client).
-- More information on password can be found in [Create a secure password](/operation/client/#create-a-secure-password).
+- More information on configuration file name can be found in [Configuring Hummingbot](/operation/config-files).
+- More information on password can be found in [Create a secure password](/operation/password).

--- a/content/release-notes/0.38.0.mdx
+++ b/content/release-notes/0.38.0.mdx
@@ -69,7 +69,7 @@ Learn more about the feature [here](/features/rate-oracle/).
 
 The new global configuration lets you choose from `start` and `config` when importing a strategy already created.
 
-Learn more about it [here](/operation/command-ref/#autofill-import).
+Learn more about it [here](/operation/config-files/#autofill-import).
 
 ## Bug Fixes
 


### PR DESCRIPTION
Remaining broken links fixed. Release Notes & Strategy Autostart content link. 
Autofill import inserted in config files.


Removed export private keys(june 3 5pm commit)
![6v4pzSXo77](https://user-images.githubusercontent.com/72089799/120618085-4c08a580-c48d-11eb-9863-f7cf39be5b6a.png)
