### PR TITLE
doc/orderlevels_orderoverride_avellaneda

### DIFF
--- a/content/strategies/avellaneda-market-making.mdx
+++ b/content/strategies/avellaneda-market-making.mdx
@@ -264,3 +264,36 @@ Number of ticks used as a sample size for volatility calculation.
   prompt="Enter amount of ticks that will be stored to calculate volatility"
   response=">>>"
 />
+
+### `order_levels`
+
+Quantity of orders to be placed on each side of the order book.
+
+For example, if `order_levels = 2` , it will place **2 Buy Orders & 2 Sell Orders**.
+
+** Prompt: **
+
+<Prompt
+  prompt="How many orders do you want to place on both sides?"
+  response=">>>"
+/>
+
+### `order_override`
+
+Directly override orders placed by `order_amount` and `order_level_parameter`.
+
+To start this override feature, users must input the parameters manually in the strategy config file they intend to use. Learn how to access config files with this [documentation](/operation/config-files).
+
+Below is a sample input in dictionary format.
+
+The key is a user-defined order name and the value is a list which includes **buy/sell, order spread, and order amount**:
+
+```
+order_override:
+  order_1: [buy, 0.5, 100]
+  order_2: [buy, 0.75, 200]
+  order_3: [sell, 0.1, 500]
+
+  # Please make sure there is a space between : and [
+  # order_1 label can be renamed to custom labels
+```


### PR DESCRIPTION
Order levels and order override:


![sohKRze2FY](https://user-images.githubusercontent.com/72089799/122157423-671be200-ce9d-11eb-8509-5e7bd6a8c97b.png)
