### PR TITLE
doc / release notes broken link fix

### DIFF
--- a/content/release-notes/0.15.0.mdx
+++ b/content/release-notes/0.15.0.mdx
@@ -8,7 +8,7 @@ title: "Version 0.15.0"
 
 This often-asked-for, long-awaited feature is now released! Users can now run Hummingbot and simulate trading strategies without executing and placing actual trades.
 
-For more information on configuring and using this strategy, see [Paper Trading Mode](/operation/command-ref/#paper_trade).
+For more information on configuring and using this strategy, see [Paper Trading Mode](/operation/overview/#hummingbot-commands).
 
 ## 📊 Improvements to the **pure market making** strategy
 

--- a/content/release-notes/0.26.0.mdx
+++ b/content/release-notes/0.26.0.mdx
@@ -26,7 +26,7 @@ We have extensively revamped the commands in Hummingbot. New commands include:
 - `create`: create a bot
 - `import`: import an existing bot configuration
 
-See the [Command Reference](/operation/command-ref/) for all commands.
+See the [Command Reference](/operation/overview/#hummingbot-commands) for all commands.
 
 ## 🍱 Standardized parameter names and spread/percent inputs
 
@@ -40,7 +40,7 @@ Any parameter names that end with `-pct` or `-spread` use this format.
 
 An often-requested feature is the ability to adjust the bot without stopping it. So we have started to make more parameters adjustable on the fly, starting with spreads.
 
-Now you can use the revamped [config](/operation/command-ref/#config) command to adjust spreads without stopping the bot. We plan to extend this functionality to other parameters such as order amount in the future.
+Now you can use the revamped [config](/operation/overview/#hummingbot-commands) command to adjust spreads without stopping the bot. We plan to extend this functionality to other parameters such as order amount in the future.
 
 ## 🔗 New Kraken connector
 

--- a/content/release-notes/0.30.0.mdx
+++ b/content/release-notes/0.30.0.mdx
@@ -20,7 +20,7 @@ For more information and sample usage, refer to [balance command](/operation/bal
 
 ## 📖 New command: Order Book
 
-Users can now see the market's order book by running the [order_book](/operation/command-ref/#order_book) command from the Hummingbot CLI while a strategy is running.
+Users can now see the market's order book by running the [order_book](/operation/overview/#hummingbot-commands) command from the Hummingbot CLI while a strategy is running.
 
 By default, this command shows the top 5 bid/ask prices with order volume. It can be used with optional arguments like `--lines` to specify the number of lines to show, `--markets` and `--exchange` if running on cross-exchange and arbitrage strategy.
 


### PR DESCRIPTION
Fixed broken link on release notes : 
- v.0.30
- v0.15
- v0.26

![image](https://user-images.githubusercontent.com/85161223/122937891-e67d4a00-d3a4-11eb-9a01-53e69721c74f.png)
![image](https://user-images.githubusercontent.com/85161223/122938024-fb59dd80-d3a4-11eb-944a-e0b76844cc1d.png)
![image](https://user-images.githubusercontent.com/85161223/122938100-11679e00-d3a5-11eb-9f7c-1fe12729d8c6.png)
