### PR TITLE
doc / add parameter links and kucoin troubleshooting

### DIFF
--- a/content/strategies/avellaneda-market-making.mdx
+++ b/content/strategies/avellaneda-market-making.mdx
@@ -114,7 +114,9 @@ The maximum spread related to the mid price allowed by user for bid/ask orders
 
 ### `volatility_sensibility`
 
-The Volatility Sensibility will recalculate `gamma`, `kappa` and `eta` after the value of volatility sensibility threshold in percentage is achieved. For example, when the parameter is set to 0, it will recalculate `gamma`, `kappa`, and `eta` each time an order is created. The default value for the parameter is 20.
+The Volatility Sensibility will recalculate `gamma`, `kappa`, and `eta` after the value of volatility sensibility threshold in percentage is achieved. For example, when the parameter is set to 0, it will recalculate `gamma`, `kappa`, and `eta` each time an order is created. The default value for the parameter is 20.
+
+You can visit this introduction and detailed information on this parameter from this [link](https://docs.hummingbot.io/release-notes/0.39.0/) to know more.
 
 ** Prompt: **
 
@@ -222,6 +224,8 @@ The `max_order_age` parameter allows you to set a specific duration when resetti
 ### `order_refresh_tolerance_pct`
 
 The spread (from mid-price) to defer the order refresh process to the next cycle.
+
+To know more about this parameter you can visit this [link](https://docs.hummingbot.io/strategies/order-refresh-tolerance/#gatsby-focus-wrapper)
 
 ** Prompt: **
 

--- a/content/troubleshooting/connectors.mdx
+++ b/content/troubleshooting/connectors.mdx
@@ -23,10 +23,10 @@ binance.exceptions.BinanceAPIException: APIError(code=-1003): Way too much reque
 
 This error occurs when the Binance API rate limit is reached. Causes include:
 
-Using multiple order mode with 3+ orders per side
-High order refresh rate
-Running multiple instances of Hummingbot
-Weight/Request error in logs happens when it encounters a warning or error and Hummingbot repeatedly sends the request (fetching status updates, placing/canceling orders, etc.) which resulted in getting banned. This should be lifted after a couple of hours or up to a maximum of 24 hours.
+- Using multiple order mode with 3+ orders per side
+- High order refresh rate
+- Running multiple instances of Hummingbot
+- Weight/Request error in logs happens when it encounters a warning or error and Hummingbot repeatedly sends the request (fetching status updates, placing/canceling orders, etc.) which resulted in getting banned. This should be lifted after a couple of hours or up to a maximum of 24 hours.
 
 ---
 
@@ -42,3 +42,18 @@ Failed connections:                                                             
 ```
 
 This error occurs when Kraken account currently has no funds on the exchange. Fund your account to fix the error. For more info, visit this [here](https://support.kraken.com/hc/en-us/articles/360001491786-API-Error-Codes).
+
+---
+
+## Kucoin
+
+### Failed to submit buy order to Kucoin. Check API key and network connection
+
+```
+kucoin_exchange - Failed to submit buy order to Kucoin. Check API key and network connection.
+```
+
+This error occurs when the exchange has an insufficient balance to create an order. Possible causes:
+
+- `order_amount` was set to a higher value compared to your token balance
+- When using a `liquidity_mining` strategy, check if you have the proper `token` set to provide liquidity


### PR DESCRIPTION
Added links on `Avellaneda` Strategy docs to provide more details about the parameters. 

`volatility_sensibility`
![image](https://user-images.githubusercontent.com/78310937/123477921-543da600-d631-11eb-9a72-4809a50baa95.png)

Which routes you over to: 
![image](https://user-images.githubusercontent.com/78310937/123477955-61f32b80-d631-11eb-87ed-d51abdd97dce.png)

`order_refresh_tolerance_pct`
![image](https://user-images.githubusercontent.com/78310937/123478086-87803500-d631-11eb-9518-4ef31c5187f6.png)

Routes to: 

![image](https://user-images.githubusercontent.com/78310937/123478133-9bc43200-d631-11eb-8303-94f8281a7b8a.png)

Also, added a troubleshooting document for Kucoin's commonly reported issue "Failed to submit buy order to Kucoin. Check API key and network connection"

![image](https://user-images.githubusercontent.com/78310937/123478268-ca420d00-d631-11eb-8410-0c92d4866f87.png)
