### PR TITLE
doc / updated bitmax to ascendex

### DIFF
--- a/content/release-notes/0.36.0.mdx
+++ b/content/release-notes/0.36.0.mdx
@@ -11,13 +11,13 @@ _Released on February 08, 2021_
 
 ---
 
-## New Exchange Connector: BitMax
+## New Exchange Connector: AscendEX
 
-In this release, Hummingbot has added two more exchanges in its vast spectrum of connectors. Hummingbot now supports [BitMax](https://bitmax.io/en/global-digital-asset-platform) exchange! BitMax describes itself as a global digital asset trading platform; exchange for Bitcoin and other crypto coins & tokens; innovator of staking, margin & derivative trading products. BitMax is a Singapore-based crypto exchange launched in July 2018. The bitmax.io domain name was created on February 23, 2018. The exchange offers crypto-to-crypto trading of 36 coins in 72 pairs with three markets (BTC, USDT, and ETH).
+In this release, Hummingbot has added two more exchanges in its vast spectrum of connectors. Hummingbot now supports [AscendEX](https://ascendex.com/en/global-digital-asset-platform) exchange! AscendEX describes itself as a global digital asset trading platform; exchange for Bitcoin and other crypto coins & tokens; innovator of staking, margin & derivative trading products. AscendEX is a Singapore-based crypto exchange launched in July 2018. The bitmax.io domain name (now AscendEX) was created on February 23, 2018. The exchange offers crypto-to-crypto trading of 36 coins in 72 pairs with three markets (BTC, USDT, and ETH).
 
-Bitmax is compatible with [pure market making](https://docs.hummingbot.io/strategies/pure-market-making/), [cross-exchange market-making](/strategies/cross-exchange-market-making/), and [arbitrage strategies](/strategies/arbitrage/).
+AscendEX is compatible with [pure market making](https://docs.hummingbot.io/strategies/pure-market-making/), [cross-exchange market-making](/strategies/cross-exchange-market-making/), and [arbitrage strategies](/strategies/arbitrage/).
 
-Read more about how to use the BitMax connector [here](/spot-connectors/ascend-ex/).
+Read more about how to use the AscendEX connector [here](/spot-connectors/ascend-ex/).
 
 ## New Exchange Connector: Blocktane
 


### PR DESCRIPTION
Updated the v.36.0 Release note for Bitmax now changed to AscendEX. 

![image](https://user-images.githubusercontent.com/78310937/123521977-b4455280-d6ec-11eb-8068-8961e73c1a3a.png)
