### PR TITLE
Tmux conda issues resolve

### DIFF
--- a/content/installation/multiple-bots.mdx
+++ b/content/installation/multiple-bots.mdx
@@ -87,6 +87,7 @@ When using screen to run an instance in the background, run either of the follow
 Navigate to the folder where your separate Hummingbot is installed, then start the bot like normal.
 
 ```
+conda deactivate
 conda activate hummingbot
 bin/hummingbot.py
 ```


### PR DESCRIPTION
Due to strange tmux (and I think screen) behaviour that [uses](https://github.com/conda/conda/issues/6826) .bash_profile instead of current activated (the bug is alive till now!), it's needed to deactivate this default env & then activate hummingbot env. Otherwise you'll get the `ModuleNotFoundError` on start.
