### PR TITLE
Fix docker run command in autostart script example

### DIFF
--- a/content/operation/strategy-autostart.mdx
+++ b/content/operation/strategy-autostart.mdx
@@ -61,7 +61,7 @@ export CONFIG_FILE_NAME=<strategy config file name>
 export CONFIG_PASSWORD=<config password>
 
 # 5) Launch unattended instance of Hummingbot
-docker run -d \
+docker run -itd \
   --name hummingbot-instance \
   --network host \
   --mount "type=bind,source=$(pwd)/hummingbot_files/hummingbot_conf,destination=/conf/" \


### PR DESCRIPTION
The command as currently shown in the example does not work. Hummingbot crashes without a pseudo-TTY. Adding `-t` at a minimum fixes this. Adding `-i` to keep STDIN open, even when the container is detached, seems like a good idea as well, though it may not be required. Including it does not seem to cause any problems.