### PR TITLE
Fix links to executables and NDAX connector documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "workbench.colorTheme": "Default Light+"
+}

--- a/content/release-notes/0.42.0.mdx
+++ b/content/release-notes/0.42.0.mdx
@@ -4,7 +4,7 @@ title: August 2021 (v0.42.0)
 
 _Released on August 11, 2021_
 
-- **Download Installer**: [Windows](https://dist.hummingbot.io/hummingbot_v0.41.0_setup.exe) | [macOS](https://dist.hummingbot.io/hummingbot_v0.41.0.dmg)
+- **Download Installer**: [Windows](https://dist.hummingbot.io/hummingbot_v0.42.0_setup.exe) | [macOS](https://dist.hummingbot.io/hummingbot_v0.42.0.dmg)
 - **Install via Docker**: [Linux](https://docs.hummingbot.io/installation/linux/#install-via-docker) | [Windows](https://docs.hummingbot.io/installation/windows/#install-via-docker) | [Mac](https://docs.hummingbot.io/installation/mac/#install-via-docker) | [Raspberry Pi](https://docs.hummingbot.io/installation/raspberry/)
 
 ---
@@ -15,7 +15,7 @@ _Released on August 11, 2021_
 
 They are incorporated in the province of Alberta and registered as a Money Service Business (MSB), making them subject to the Proceeds of Crime (Money Laundering) and Terrorist Financing Act (PCMLTFA) and applicable regulatory framework of the Financial Transactions and Reports and Analysis Centre of Canada (FINTRAC).
 
-Read more in our documentation: [How to use NDAX connector](/connectors/ndax)
+Read more in our documentation: [How to use NDAX connector](/spot-connectors/ndax)
 
 ## New Global Config: Rate Limits Share Pct
 


### PR DESCRIPTION
Same as https://github.com/CoinAlpha/hummingbot/pull/3918 for the old docs site